### PR TITLE
No default features of bstr

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,5 @@ description = "SDP (RFC 4566) types, parser and serializer"
 readme = "README.md"
 
 [dependencies]
-bstr = "1"
+bstr = { version = "1", default-features = false }
 fallible-iterator = "0.3"


### PR DESCRIPTION
This helps reduce the binary size because `regex_automa` is huge.