### PR TITLE
Add constructors, setters, adders & builders

### DIFF
--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -244,8 +244,28 @@ pub struct Rtcp {
     pub nettype: NetType,
     /// Address type
     pub addrtype: AddrType,
-    /// IP Address, unicast or multicast
-    pub connection_address: IpAddr,
+    /// Connection address: can be IP Address, unicast, multicast, ...
+    /// Conformity may be checked against the `addrtype`.
+    pub connection_address: String,
+}
+
+impl Rtcp {
+    /// Sets the `connection_address` & `addrtype` of `self` from the specified `IpAddr`
+    pub fn set_connection_ip_address(&mut self, connection_address: impl Into<IpAddr>) {
+        let connection_address = connection_address.into();
+        self.addrtype = connection_address.into();
+        self.connection_address = connection_address.to_string();
+    }
+
+    /// Tries to parse the `connection_address` `String` of `self` as `IpAddr`
+    ///
+    /// Returns the `Ok` with the parsed `IpAddr` or `Err` with the string address
+    /// if parsing failed.
+    pub fn try_parse_connection_ip_address(&self) -> Result<IpAddr, &str> {
+        self.connection_address
+            .parse::<IpAddr>()
+            .map_err(|_| self.connection_address.as_str())
+    }
 }
 
 impl FromStr for Rtcp {
@@ -298,17 +318,9 @@ impl FromStr for Rtcp {
             });
         };
 
-        let Some(connection_addr) = i.next() else {
+        let Some(connection_address) = i.next() else {
             return Err(AttributeError::ParamNotFound {
                 param: "Connection address".to_string(),
-                attr: <Self as TypedAttribute>::NAME.to_string(),
-            });
-        };
-
-        let Ok(connection_address) = connection_addr.parse() else {
-            return Err(AttributeError::InvalidParamValue {
-                param: "Connection address".to_string(),
-                val: connection_addr.to_string(),
                 attr: <Self as TypedAttribute>::NAME.to_string(),
             });
         };
@@ -324,7 +336,7 @@ impl FromStr for Rtcp {
             port,
             nettype,
             addrtype,
-            connection_address,
+            connection_address: connection_address.to_string(),
         })
     }
 }
@@ -1716,6 +1728,8 @@ impl TypedAttribute for Candidate {
 
 #[cfg(test)]
 mod tests {
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
     use super::*;
     use crate::*;
 
@@ -2129,14 +2143,6 @@ a=candidate:7 1 UDP 10 192.168.1.1 49157 typ unknown_type\r
                 attr: "rtcp".to_string()
             }
         );
-        assert_eq!(
-            "53020 invalid IP4 127.0.0.1".parse::<Rtcp>().unwrap_err(),
-            AttributeError::InvalidParamValue {
-                param: "Network type".to_string(),
-                val: "invalid".to_string(),
-                attr: "rtcp".to_string()
-            }
-        );
 
         // Test Fingerprint error paths
         assert_eq!(
@@ -2296,6 +2302,56 @@ a=candidate:7 1 UDP 10 192.168.1.1 49157 typ unknown_type\r
                 error: "No value for the attribute".to_string(),
                 attr: "rtpmap".to_string()
             }
+        );
+    }
+
+    #[test]
+    fn parse_rtcp_address() {
+        let sdp = "v=0\r
+o=alice 3203093520 3203093520 IN IP4 host.example.com\r
+s=parse rtcp attribute address test\r
+a=rtcp:5000 IN IP4 127.0.0.1\r
+a=rtcp:5000 IN IP4 127.0.0.0/24\r
+a=rtcp:5000 IN IP6 ::1\r
+a=rtcp:5000 IN NONIP non-IP\r
+";
+
+        let parsed = Session::parse(sdp.as_bytes()).unwrap();
+        let mut rtcp_attr_iter = parsed.attributes_typed::<Rtcp>();
+
+        let rtcp = rtcp_attr_iter.next().unwrap().unwrap();
+        assert_eq!(rtcp.addrtype, AddrType::Ip4);
+        assert_eq!(&rtcp.connection_address, "127.0.0.1");
+        assert_eq!(
+            rtcp.try_parse_connection_ip_address().unwrap(),
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+        );
+
+        let rtcp = rtcp_attr_iter.next().unwrap().unwrap();
+        assert_eq!(rtcp.addrtype, AddrType::Ip4);
+        assert_eq!(&rtcp.connection_address, "127.0.0.0/24");
+        assert_eq!(
+            &rtcp
+                .try_parse_connection_ip_address()
+                .expect_err("IPv4 with mask")
+                .to_string(),
+            "127.0.0.0/24"
+        );
+
+        let rtcp = rtcp_attr_iter.next().unwrap().unwrap();
+        assert_eq!(rtcp.addrtype, AddrType::Ip6);
+        assert_eq!(&rtcp.connection_address, "::1");
+        assert_eq!(
+            rtcp.try_parse_connection_ip_address().unwrap(),
+            IpAddr::V6(Ipv6Addr::LOCALHOST),
+        );
+
+        let rtcp = rtcp_attr_iter.next().unwrap().unwrap();
+        assert_eq!(rtcp.addrtype, AddrType::Other("NONIP".to_string()));
+        assert_eq!(&rtcp.connection_address, "non-IP");
+        assert_eq!(
+            rtcp.try_parse_connection_ip_address().unwrap_err(),
+            "non-IP",
         );
     }
 }

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -1139,6 +1139,31 @@ impl Ssrc {
     pub fn set_value(&mut self, value: impl ToString) {
         self.value = Some(value.to_string());
     }
+
+    /// Gets the inner attribute as a `TypedAttribute`.
+    ///
+    /// # Errors
+    ///
+    /// * `AttributeError::Other` if the inner attribute doesn't match
+    ///   the specified `TypedAttribute` or if the value is empty.
+    /// * a specific `AttributeError` if the typed attribute couldn't be built.
+    pub fn get_typed<T: TypedAttribute>(&self) -> Result<T, AttributeError> {
+        if !self.attribute.as_str().eq_ignore_ascii_case(T::NAME) {
+            return Err(AttributeError::Other {
+                error: format!("Attribute type mismatch (requested {})", T::NAME),
+                attr: self.attribute.as_str().to_string(),
+            });
+        }
+
+        let Some(ref value) = self.value else {
+            return Err(AttributeError::Other {
+                error: "No value for the attribute".to_string(),
+                attr: T::NAME.to_string(),
+            });
+        };
+
+        T::from_str(value)
+    }
 }
 
 impl FromStr for Ssrc {

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -10,11 +10,20 @@ use std::{
     str::FromStr,
 };
 
-use crate::enums::*;
+use crate::{builders, enums::*, Attribute};
 
 /// Trait for Typed Attribute structs
 pub trait TypedAttribute: Display + FromStr<Err = AttributeError> {
     const NAME: &'static str;
+}
+
+impl<T: TypedAttribute> From<T> for Attribute {
+    fn from(attr: T) -> Attribute {
+        Attribute {
+            attribute: T::NAME.to_string(),
+            value: Some(attr.to_string()),
+        }
+    }
 }
 
 /// Attribute error with specific details
@@ -62,6 +71,43 @@ pub struct RtpMap {
     ///
     /// Currently used only for audio channel count
     pub encoding_params: Option<String>,
+}
+
+impl RtpMap {
+    pub fn new(payload_type: u8, encoding_name: impl ToString, clock_rate: u32) -> Self {
+        RtpMap {
+            payload_type,
+            encoding_name: encoding_name.to_string(),
+            clock_rate,
+            encoding_params: None,
+        }
+    }
+
+    pub fn builder(
+        payload_type: u8,
+        encoding_name: impl ToString,
+        clock_rate: u32,
+    ) -> builders::RtpMap {
+        builders::RtpMap::new(payload_type, encoding_name, clock_rate)
+    }
+
+    pub fn with_encoding_params(
+        payload_type: u8,
+        encoding_name: impl ToString,
+        clock_rate: u32,
+        encoding_params: impl ToString,
+    ) -> Self {
+        RtpMap {
+            payload_type,
+            encoding_name: encoding_name.to_string(),
+            clock_rate,
+            encoding_params: Some(encoding_params.to_string()),
+        }
+    }
+
+    pub fn set_encoding_params(&mut self, encoding_params: impl ToString) {
+        self.encoding_params = Some(encoding_params.to_string());
+    }
 }
 
 impl FromStr for RtpMap {
@@ -152,6 +198,30 @@ pub struct FmtpParam {
     pub val: Option<String>,
 }
 
+impl FmtpParam {
+    pub fn new(param: impl ToString) -> Self {
+        FmtpParam {
+            param: param.to_string(),
+            val: None,
+        }
+    }
+
+    pub fn builder(param: impl ToString) -> builders::FmtpParam {
+        builders::FmtpParam::new(param)
+    }
+
+    pub fn with_value(param: impl ToString, value: impl ToString) -> Self {
+        FmtpParam {
+            param: param.to_string(),
+            val: Some(value.to_string()),
+        }
+    }
+
+    pub fn set_value(&mut self, value: impl ToString) {
+        self.val = Some(value.to_string());
+    }
+}
+
 /// Format Parameters
 ///
 /// See [RFC 8866 Section 6.15](https://datatracker.ietf.org/doc/html/rfc8866#section-6.15) for more details
@@ -164,6 +234,30 @@ pub struct Fmtp {
     // Multiple params are expected to be semicolon separated
     // Each param can be a 'key=value' pair or just single parameter
     pub format_specific_params: Vec<FmtpParam>,
+}
+
+impl Fmtp {
+    pub fn new(fmt: u8) -> Self {
+        Fmtp {
+            fmt,
+            format_specific_params: vec![],
+        }
+    }
+
+    pub fn builder(fmt: u8) -> builders::Fmtp {
+        builders::Fmtp::new(fmt)
+    }
+
+    pub fn add_format_specific_param(&mut self, format_specific_param: FmtpParam) {
+        self.format_specific_params.push(format_specific_param)
+    }
+
+    pub fn add_format_specific_params(
+        &mut self,
+        format_specific_params: impl IntoIterator<Item = FmtpParam>,
+    ) {
+        self.format_specific_params.extend(format_specific_params)
+    }
 }
 
 impl FromStr for Fmtp {
@@ -250,11 +344,32 @@ pub struct Rtcp {
 }
 
 impl Rtcp {
-    /// Sets the `connection_address` & `addrtype` of `self` from the specified `IpAddr`
-    pub fn set_connection_ip_address(&mut self, connection_address: impl Into<IpAddr>) {
+    /// Construct an [`Rtcp`] with the specified IP `connection_address`
+    pub fn with_ip_addr(port: u16, connection_address: impl Into<IpAddr>) -> Self {
         let connection_address = connection_address.into();
-        self.addrtype = connection_address.into();
-        self.connection_address = connection_address.to_string();
+        Rtcp {
+            port,
+            nettype: NetType::In,
+            addrtype: connection_address.into(),
+            connection_address: connection_address.to_string(),
+        }
+    }
+
+    /// Construct an [`Rtcp`]
+    ///
+    /// See also [`Rtcp::with_ip_addr`]
+    pub fn new(
+        port: u16,
+        nettype: NetType,
+        addrtype: AddrType,
+        connection_address: impl ToString,
+    ) -> Self {
+        Rtcp {
+            port,
+            nettype,
+            addrtype,
+            connection_address: connection_address.to_string(),
+        }
     }
 
     /// Tries to parse the `connection_address` `String` of `self` as `IpAddr`
@@ -265,6 +380,13 @@ impl Rtcp {
         self.connection_address
             .parse::<IpAddr>()
             .map_err(|_| self.connection_address.as_str())
+    }
+
+    /// Sets the `connection_address` & `addrtype` of `self` from the specified `IpAddr`
+    pub fn set_connection_ip_address(&mut self, connection_address: impl Into<IpAddr>) {
+        let connection_address = connection_address.into();
+        self.addrtype = connection_address.into();
+        self.connection_address = connection_address.to_string();
     }
 }
 
@@ -365,6 +487,12 @@ pub struct RtcpFb {
     pub pt: RtcpFbPt,
     /// RTCP Feedback value
     pub val: RtcpFbVal,
+}
+
+impl RtcpFb {
+    pub fn new(pt: RtcpFbPt, val: RtcpFbVal) -> Self {
+        RtcpFb { pt, val }
+    }
 }
 
 impl FromStr for RtcpFb {
@@ -579,6 +707,15 @@ impl Display for Direction {
     }
 }
 
+impl From<Direction> for Attribute {
+    fn from(attr: Direction) -> Attribute {
+        Attribute {
+            attribute: attr.to_string(),
+            value: None,
+        }
+    }
+}
+
 /// RTP header extensions map
 ///
 /// See [RFC 8285 Section 8](https://datatracker.ietf.org/doc/html/rfc8285#section-8)
@@ -593,6 +730,52 @@ pub struct ExtMap {
     pub uri: String,
     /// Extension attributes
     pub attributes: Option<String>,
+}
+
+impl ExtMap {
+    pub fn new(id: u8, uri: impl ToString) -> Self {
+        ExtMap {
+            id,
+            direction: None,
+            uri: uri.to_string(),
+            attributes: None,
+        }
+    }
+
+    pub fn builder(id: u8, uri: impl ToString) -> builders::ExtMap {
+        builders::ExtMap::new(id, uri)
+    }
+
+    pub fn with_direction(id: u8, direction: Direction, uri: impl ToString) -> Self {
+        ExtMap {
+            id,
+            direction: Some(direction),
+            uri: uri.to_string(),
+            attributes: None,
+        }
+    }
+
+    pub fn with_direction_and_attributes(
+        id: u8,
+        direction: Direction,
+        uri: impl ToString,
+        attributes: impl ToString,
+    ) -> Self {
+        ExtMap {
+            id,
+            direction: Some(direction),
+            uri: uri.to_string(),
+            attributes: Some(attributes.to_string()),
+        }
+    }
+
+    pub fn set_direction(&mut self, direction: Direction) {
+        self.direction = Some(direction);
+    }
+
+    pub fn set_attributes(&mut self, attributes: impl ToString) {
+        self.attributes = Some(attributes.to_string());
+    }
 }
 
 impl FromStr for ExtMap {
@@ -699,6 +882,30 @@ pub struct Fingerprint {
     pub fingerprint: Vec<u8>,
 }
 
+impl Fingerprint {
+    pub fn new(hash_func: HashFunc) -> Self {
+        Fingerprint {
+            hash_func,
+            fingerprint: vec![],
+        }
+    }
+
+    pub fn with_fingerprint(
+        hash_func: HashFunc,
+        fingerprint: impl IntoIterator<Item = u8>,
+    ) -> Self {
+        Fingerprint {
+            hash_func,
+            fingerprint: std::iter::FromIterator::from_iter(fingerprint),
+        }
+    }
+
+    pub fn set_fingerprint(&mut self, fingerprint: impl IntoIterator<Item = u8>) {
+        self.fingerprint.clear();
+        self.fingerprint.extend(fingerprint);
+    }
+}
+
 impl FromStr for Fingerprint {
     type Err = AttributeError;
 
@@ -706,23 +913,7 @@ impl FromStr for Fingerprint {
         let mut i = s.splitn(2, ' ');
 
         let hash_func = if let Some(hash_func) = i.next() {
-            if hash_func.eq_ignore_ascii_case("sha-1") {
-                HashFunc::SHA1
-            } else if hash_func.eq_ignore_ascii_case("sha-224") {
-                HashFunc::SHA224
-            } else if hash_func.eq_ignore_ascii_case("sha-256") {
-                HashFunc::SHA256
-            } else if hash_func.eq_ignore_ascii_case("sha-384") {
-                HashFunc::SHA384
-            } else if hash_func.eq_ignore_ascii_case("sha-512") {
-                HashFunc::SHA512
-            } else if hash_func.eq_ignore_ascii_case("md-5") {
-                HashFunc::MD5
-            } else if hash_func.eq_ignore_ascii_case("md-2") {
-                HashFunc::MD2
-            } else {
-                HashFunc::Other(hash_func.to_string())
-            }
+            HashFunc::new(hash_func)
         } else {
             return Err(AttributeError::ParamNotFound {
                 param: "Hash function".to_string(),
@@ -759,17 +950,7 @@ impl FromStr for Fingerprint {
 
 impl Display for Fingerprint {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let hash = match &self.hash_func {
-            HashFunc::SHA1 => "sha-1",
-            HashFunc::SHA224 => "sha-224",
-            HashFunc::SHA256 => "sha-256",
-            HashFunc::SHA384 => "sha-384",
-            HashFunc::SHA512 => "sha-512",
-            HashFunc::MD5 => "md-5",
-            HashFunc::MD2 => "md-2",
-            HashFunc::Other(s) => s.as_str(),
-        };
-        f.write_str(hash)?;
+        f.write_str(self.hash_func.as_str())?;
         let mut first = true;
         for v in &self.fingerprint {
             if first {
@@ -798,6 +979,24 @@ pub struct Group {
     pub mid_tags: Vec<String>,
 }
 
+impl Group {
+    pub fn new(semantics: GroupSemantics) -> Self {
+        Group {
+            semantics,
+            mid_tags: vec![],
+        }
+    }
+
+    pub fn add_mid_tag(&mut self, mid_tag: impl ToString) {
+        self.mid_tags.push(mid_tag.to_string())
+    }
+
+    pub fn add_mid_tags(&mut self, mid_tags: impl IntoIterator<Item = impl ToString>) {
+        self.mid_tags
+            .extend(mid_tags.into_iter().map(|i| i.to_string()))
+    }
+}
+
 impl FromStr for Group {
     type Err = AttributeError;
 
@@ -811,21 +1010,7 @@ impl FromStr for Group {
             });
         };
 
-        let semantics = if "LS".eq_ignore_ascii_case(semantics) {
-            GroupSemantics::LS
-        } else if "FID".eq_ignore_ascii_case(semantics) {
-            GroupSemantics::FID
-        } else if "SRF".eq_ignore_ascii_case(semantics) {
-            GroupSemantics::SRF
-        } else if "ANAT".eq_ignore_ascii_case(semantics) {
-            GroupSemantics::ANAT
-        } else if "FEC".eq_ignore_ascii_case(semantics) {
-            GroupSemantics::FEC
-        } else if "DDP".eq_ignore_ascii_case(semantics) {
-            GroupSemantics::DDP
-        } else {
-            GroupSemantics::Other(semantics.to_string())
-        };
+        let semantics = GroupSemantics::new(semantics);
 
         let mut mid_tags = vec![];
         for mid in i {
@@ -848,16 +1033,7 @@ impl FromStr for Group {
 
 impl Display for Group {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let sem = match &self.semantics {
-            GroupSemantics::LS => "LS",
-            GroupSemantics::FID => "FID",
-            GroupSemantics::SRF => "SRF",
-            GroupSemantics::ANAT => "ANAT",
-            GroupSemantics::DDP => "DDP",
-            GroupSemantics::FEC => "FEC",
-            GroupSemantics::Other(s) => s.as_str(),
-        };
-        f.write_str(sem)?;
+        f.write_str(self.semantics.as_str())?;
         for m in &self.mid_tags {
             f.write_char(' ')?;
             f.write_str(m)?;
@@ -934,6 +1110,37 @@ pub struct Ssrc {
     pub value: Option<String>,
 }
 
+impl Ssrc {
+    pub fn new(ssrc_id: u32, attribute: SsrcAttribute) -> Self {
+        Ssrc {
+            ssrc_id,
+            attribute,
+            value: None,
+        }
+    }
+
+    pub fn with_typed_attribute(ssrc_id: u32, attribute: impl TypedAttribute) -> Self {
+        let value = attribute.to_string();
+        Ssrc {
+            ssrc_id,
+            attribute: SsrcAttribute::from(attribute),
+            value: Some(value),
+        }
+    }
+
+    pub fn with_value(ssrc_id: u32, attribute: SsrcAttribute, value: impl ToString) -> Self {
+        Ssrc {
+            ssrc_id,
+            attribute,
+            value: Some(value.to_string()),
+        }
+    }
+
+    pub fn set_value(&mut self, value: impl ToString) {
+        self.value = Some(value.to_string());
+    }
+}
+
 impl FromStr for Ssrc {
     type Err = AttributeError;
 
@@ -959,19 +1166,9 @@ impl FromStr for Ssrc {
             (rest, None)
         };
 
-        let attribute = if "cname".eq_ignore_ascii_case(attr) {
-            SsrcAttribute::Cname
-        } else if "previous-ssrc".eq_ignore_ascii_case(attr) {
-            SsrcAttribute::PreviousSsrc
-        } else if "fmtp".eq_ignore_ascii_case(attr) {
-            SsrcAttribute::Fmtp
-        } else {
-            SsrcAttribute::Other(attr.to_string())
-        };
-
         Ok(Self {
             ssrc_id,
-            attribute,
+            attribute: SsrcAttribute::new(attr),
             value,
         })
     }
@@ -1008,6 +1205,23 @@ impl TypedAttribute for Ssrc {
 pub struct SsrcGroup {
     pub semantics: GroupSemantics,
     pub ssrc_ids: Vec<u32>,
+}
+
+impl SsrcGroup {
+    pub fn new(semantics: GroupSemantics) -> Self {
+        SsrcGroup {
+            semantics,
+            ssrc_ids: vec![],
+        }
+    }
+
+    pub fn add_ssrc_id(&mut self, ssrc_id: u32) {
+        self.ssrc_ids.push(ssrc_id)
+    }
+
+    pub fn add_ssrc_ids(&mut self, ssrc_ids: impl IntoIterator<Item = u32>) {
+        self.ssrc_ids.extend(ssrc_ids)
+    }
 }
 
 impl FromStr for SsrcGroup {
@@ -1100,6 +1314,45 @@ pub struct SrtpKeyParam {
     pub lifetime: Option<u32>,
     /// MKI (Master Key Identifier) and length of the MKI field in SRTP packets
     pub mki_and_length: Option<(u32, u32)>,
+}
+
+impl SrtpKeyParam {
+    pub fn new(key_and_salt: impl ToString) -> Self {
+        SrtpKeyParam {
+            key_and_salt: key_and_salt.to_string(),
+            lifetime: None,
+            mki_and_length: None,
+        }
+    }
+
+    pub fn with_lifetime(key_and_salt: impl ToString, lifetime: u32) -> Self {
+        SrtpKeyParam {
+            key_and_salt: key_and_salt.to_string(),
+            lifetime: Some(lifetime),
+            mki_and_length: None,
+        }
+    }
+
+    pub fn with_lifetime_and_mki_and_length(
+        key_and_salt: impl ToString,
+        lifetime: u32,
+        mki: u32,
+        length: u32,
+    ) -> Self {
+        SrtpKeyParam {
+            key_and_salt: key_and_salt.to_string(),
+            lifetime: Some(lifetime),
+            mki_and_length: Some((mki, length)),
+        }
+    }
+
+    pub fn set_lifetime(&mut self, lifetime: u32) {
+        self.lifetime = Some(lifetime);
+    }
+
+    pub fn set_mki_and_length(&mut self, mki: u32, length: u32) {
+        self.mki_and_length = Some((mki, length));
+    }
 }
 
 impl FromStr for SrtpKeyParam {
@@ -1271,6 +1524,36 @@ pub struct Crypto {
     pub session_params: Vec<SrtpSessionParam>,
 }
 
+impl Crypto {
+    pub fn new(tag: u32, crypto_suite: CryptoSuite) -> Self {
+        Crypto {
+            tag,
+            crypto_suite,
+            key_params: vec![],
+            session_params: vec![],
+        }
+    }
+
+    pub fn add_key_param(&mut self, key_param: SrtpKeyParam) {
+        self.key_params.push(key_param)
+    }
+
+    pub fn add_key_params(&mut self, key_params: impl IntoIterator<Item = SrtpKeyParam>) {
+        self.key_params.extend(key_params)
+    }
+
+    pub fn add_session_param(&mut self, session_param: SrtpSessionParam) {
+        self.session_params.push(session_param)
+    }
+
+    pub fn add_session_params(
+        &mut self,
+        session_params: impl IntoIterator<Item = SrtpSessionParam>,
+    ) {
+        self.session_params.extend(session_params)
+    }
+}
+
 impl FromStr for Crypto {
     type Err = AttributeError;
 
@@ -1299,15 +1582,7 @@ impl FromStr for Crypto {
             });
         };
 
-        let crypto_suite = if "AES_CM_128_HMAC_SHA1_32".eq_ignore_ascii_case(crypto_suite) {
-            CryptoSuite::AesCm128HmacSha1_32
-        } else if "F8_128_HMAC_SHA1_80".eq_ignore_ascii_case(crypto_suite) {
-            CryptoSuite::F8_128HmacSha1_80
-        } else if "AES_CM_128_HMAC_SHA1_80".eq_ignore_ascii_case(crypto_suite) {
-            CryptoSuite::AesCm128HmacSha1_80
-        } else {
-            CryptoSuite::Other(crypto_suite.to_string())
-        };
+        let crypto_suite = CryptoSuite::new(crypto_suite);
 
         let Some(key_params_str) = i.next() else {
             return Err(AttributeError::ParamNotFound {
@@ -1417,14 +1692,7 @@ impl FromStr for Crypto {
 
 impl Display for Crypto {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let crypto_suite_str = match &self.crypto_suite {
-            CryptoSuite::AesCm128HmacSha1_80 => "AES_CM_128_HMAC_SHA1_80",
-            CryptoSuite::AesCm128HmacSha1_32 => "AES_CM_128_HMAC_SHA1_32",
-            CryptoSuite::F8_128HmacSha1_80 => "F8_128_HMAC_SHA1_80",
-            CryptoSuite::Other(s) => s.as_str(),
-        };
-
-        write!(f, "{} {crypto_suite_str}", self.tag)?;
+        write!(f, "{} {}", self.tag, self.crypto_suite.as_str())?;
 
         for (i, key_param) in self.key_params.iter().enumerate() {
             if i == 0 {
@@ -1507,6 +1775,94 @@ pub struct Candidate {
     pub rel_port: Option<u16>,
     /// Extensions
     pub extensions: Vec<(String, String)>,
+}
+
+impl Candidate {
+    pub fn new(
+        foundation: impl ToString,
+        component_id: u32,
+        transport: impl ToString,
+        priority: u64,
+        address: CandidateAddress,
+        port: u16,
+        typ: CandidateType,
+    ) -> Self {
+        Candidate {
+            foundation: foundation.to_string(),
+            component_id,
+            transport: transport.to_string(),
+            priority,
+            address,
+            port,
+            typ,
+            rel_addr: None,
+            rel_port: None,
+            extensions: vec![],
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn with_rel_addr(
+        foundation: impl ToString,
+        component_id: u32,
+        transport: impl ToString,
+        priority: u64,
+        address: CandidateAddress,
+        port: u16,
+        typ: CandidateType,
+        rel_addr: impl Into<IpAddr>,
+    ) -> Self {
+        Candidate {
+            foundation: foundation.to_string(),
+            component_id,
+            transport: transport.to_string(),
+            priority,
+            address,
+            port,
+            typ,
+            rel_addr: Some(rel_addr.into()),
+            rel_port: None,
+            extensions: vec![],
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn with_rel_addr_and_port(
+        foundation: impl ToString,
+        component_id: u32,
+        transport: impl ToString,
+        priority: u64,
+        address: CandidateAddress,
+        port: u16,
+        typ: CandidateType,
+        rel_addr: impl Into<IpAddr>,
+        rel_port: u16,
+    ) -> Self {
+        Candidate {
+            foundation: foundation.to_string(),
+            component_id,
+            transport: transport.to_string(),
+            priority,
+            address,
+            port,
+            typ,
+            rel_addr: Some(rel_addr.into()),
+            rel_port: Some(rel_port),
+            extensions: vec![],
+        }
+    }
+
+    pub fn set_rel_addr(&mut self, rel_addr: impl Into<IpAddr>) {
+        self.rel_addr = Some(rel_addr.into());
+    }
+
+    pub fn set_rel_port(&mut self, rel_port: u16) {
+        self.rel_port = Some(rel_port);
+    }
+
+    pub fn add_extension(&mut self, name: impl ToString, value: impl ToString) {
+        self.extensions.push((name.to_string(), value.to_string()))
+    }
 }
 
 impl FromStr for Candidate {
@@ -1607,17 +1963,7 @@ impl FromStr for Candidate {
             });
         };
 
-        let cand_type = if "host".eq_ignore_ascii_case(cand_type) {
-            CandidateType::Host
-        } else if "srflx".eq_ignore_ascii_case(cand_type) {
-            CandidateType::Srflx
-        } else if "prflx".eq_ignore_ascii_case(cand_type) {
-            CandidateType::Prflx
-        } else if "relay".eq_ignore_ascii_case(cand_type) {
-            CandidateType::Relay
-        } else {
-            CandidateType::Other(cand_type.to_string())
-        };
+        let cand_type = CandidateType::new(cand_type);
 
         let mut rel_addr: Option<IpAddr> = None;
         let mut rel_port: Option<u16> = None;
@@ -1687,27 +2033,20 @@ impl FromStr for Candidate {
 
 impl Display for Candidate {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let typ = match &self.typ {
-            CandidateType::Host => "host",
-            CandidateType::Srflx => "srflx",
-            CandidateType::Prflx => "prflx",
-            CandidateType::Relay => "relay",
-            CandidateType::Other(o) => o.as_str(),
-        };
-
         let candidate_addr = match &self.address {
             CandidateAddress::IpAddr(a) => a.to_string(),
             CandidateAddress::FQDN(d) => d.clone(),
         };
         write!(
             f,
-            "{} {} {} {} {} {} typ {typ}",
+            "{} {} {} {} {} {} typ {}",
             self.foundation,
             self.component_id,
             self.transport,
             self.priority,
             candidate_addr,
-            self.port
+            self.port,
+            self.typ.as_str(),
         )?;
         if let Some(rel_addr) = self.rel_addr {
             write!(f, " raddr {rel_addr}")?;

--- a/src/builders.rs
+++ b/src/builders.rs
@@ -1,0 +1,1533 @@
+// Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
+
+//! Builders for the `sdp_types` `struct`s
+
+use crate::{attributes, enums};
+use std::net::IpAddr;
+
+/// A [`crate::Origin`] builder.
+#[derive(Debug)]
+pub struct Origin(crate::Origin);
+impl Origin {
+    /// Construct an [`crate::builders::Origin`] with the specified IP `unicast_address`
+    pub fn with_ip_addr(
+        sess_id: impl ToString,
+        sess_version: u64,
+        unicast_address: impl Into<IpAddr>,
+    ) -> Self {
+        Self(crate::Origin::with_ip_addr(
+            sess_id,
+            sess_version,
+            unicast_address,
+        ))
+    }
+
+    /// Construct an [`crate::builders::Origin`]
+    ///
+    /// See also [`crate::Origin::builder_with_ip_addr`]
+    pub fn new(
+        sess_id: impl ToString,
+        sess_version: u64,
+        nettype: enums::NetType,
+        addrtype: enums::AddrType,
+        unicast_address: impl ToString,
+    ) -> Self {
+        Self(crate::Origin::new(
+            sess_id,
+            sess_version,
+            nettype,
+            addrtype,
+            unicast_address,
+        ))
+    }
+
+    pub fn username(mut self, username: impl ToString) -> Self {
+        self.0.set_username(username);
+        self
+    }
+
+    pub fn username_if(mut self, username: impl ToString, predicate: bool) -> Self {
+        if predicate {
+            self.0.set_username(username);
+        }
+        self
+    }
+
+    pub fn username_if_some(mut self, username: Option<impl ToString>) -> Self {
+        if let Some(username) = username {
+            self.0.set_username(username);
+        }
+        self
+    }
+
+    pub fn build(self) -> crate::Origin {
+        self.0
+    }
+}
+
+/// A [`crate::Origin`] builder.
+#[derive(Debug)]
+pub struct Time(crate::Time);
+impl Time {
+    pub fn new(start_time: u64, stop_time: u64) -> Self {
+        Self(crate::Time::new(start_time, stop_time))
+    }
+
+    pub fn repeat(mut self, repeat: crate::Repeat) -> Self {
+        self.0.add_repeat(repeat);
+        self
+    }
+
+    pub fn repeat_if(mut self, repeat: crate::Repeat, predicate: bool) -> Self {
+        if predicate {
+            self.0.add_repeat(repeat);
+        }
+        self
+    }
+
+    pub fn repeat_if_some(mut self, repeat: Option<crate::Repeat>) -> Self {
+        if let Some(repeat) = repeat {
+            self.0.add_repeat(repeat);
+        }
+        self
+    }
+
+    pub fn repeats(mut self, repeats: impl IntoIterator<Item = crate::Repeat>) -> Self {
+        self.0.add_repeats(repeats);
+        self
+    }
+
+    pub fn repeats_if(
+        mut self,
+        repeats: impl IntoIterator<Item = crate::Repeat>,
+        predicate: bool,
+    ) -> Self {
+        if predicate {
+            self.0.add_repeats(repeats);
+        }
+        self
+    }
+
+    pub fn build(self) -> crate::Time {
+        self.0
+    }
+}
+
+/// A [`crate::Repeat`] builder.
+#[derive(Debug)]
+pub struct Repeat(crate::Repeat);
+impl Repeat {
+    pub fn new(repeat_interval: u64, active_duration: u64) -> Self {
+        Self(crate::Repeat::new(repeat_interval, active_duration))
+    }
+
+    pub fn offset(mut self, repeat: u64) -> Self {
+        self.0.add_offset(repeat);
+        self
+    }
+
+    pub fn offset_if(mut self, offset: u64, predicate: bool) -> Self {
+        if predicate {
+            self.0.add_offset(offset);
+        }
+        self
+    }
+
+    pub fn offset_if_some(mut self, offset: Option<u64>) -> Self {
+        if let Some(offset) = offset {
+            self.0.add_offset(offset);
+        }
+        self
+    }
+
+    pub fn offsets(mut self, offsets: impl IntoIterator<Item = u64>) -> Self {
+        self.0.add_offsets(offsets);
+        self
+    }
+
+    pub fn offsets_if(mut self, offsets: impl IntoIterator<Item = u64>, predicate: bool) -> Self {
+        if predicate {
+            self.0.add_offsets(offsets);
+        }
+        self
+    }
+
+    pub fn build(self) -> crate::Repeat {
+        self.0
+    }
+}
+
+/// A [`crate::Media`] builder.
+#[derive(Debug)]
+pub struct Media(crate::Media);
+impl Media {
+    pub fn new(
+        media: enums::MediaType,
+        port: u16,
+        proto: enums::TransportProto,
+        fmt: impl ToString,
+    ) -> Self {
+        Self(crate::Media::new(media, port, proto, fmt))
+    }
+
+    pub fn num_ports(mut self, num_ports: u16) -> Self {
+        self.0.set_num_ports(num_ports);
+        self
+    }
+
+    pub fn num_ports_if(mut self, num_ports: u16, predicate: bool) -> Self {
+        if predicate {
+            self.0.set_num_ports(num_ports);
+        }
+        self
+    }
+
+    pub fn num_ports_if_some(mut self, num_ports: Option<u16>) -> Self {
+        if let Some(num_ports) = num_ports {
+            self.0.set_num_ports(num_ports);
+        }
+        self
+    }
+
+    pub fn media_title(mut self, media_title: impl ToString) -> Self {
+        self.0.set_media_title(media_title);
+        self
+    }
+
+    pub fn media_title_if(mut self, media_title: impl ToString, predicate: bool) -> Self {
+        if predicate {
+            self.0.set_media_title(media_title);
+        }
+        self
+    }
+
+    pub fn media_title_if_some(mut self, media_title: Option<impl ToString>) -> Self {
+        if let Some(media_title) = media_title {
+            self.0.set_media_title(media_title);
+        }
+        self
+    }
+
+    pub fn connection(mut self, connection: impl Into<crate::Connection>) -> Self {
+        self.0.add_connection(connection);
+        self
+    }
+
+    pub fn connection_if(
+        mut self,
+        connection: impl Into<crate::Connection>,
+        predicate: bool,
+    ) -> Self {
+        if predicate {
+            self.0.add_connection(connection);
+        }
+        self
+    }
+
+    pub fn connection_if_some(mut self, connection: Option<impl Into<crate::Connection>>) -> Self {
+        if let Some(connection) = connection {
+            self.0.add_connection(connection);
+        }
+        self
+    }
+
+    pub fn connections(
+        mut self,
+        connections: impl IntoIterator<Item = impl Into<crate::Connection>>,
+    ) -> Self {
+        self.0.add_connections(connections);
+        self
+    }
+
+    pub fn connections_if(
+        mut self,
+        connections: impl IntoIterator<Item = impl Into<crate::Connection>>,
+        predicate: bool,
+    ) -> Self {
+        if predicate {
+            self.0.add_connections(connections);
+        }
+        self
+    }
+
+    pub fn bandwidth(mut self, bandwidth: crate::Bandwidth) -> Self {
+        self.0.add_bandwidth(bandwidth);
+        self
+    }
+
+    pub fn bandwidth_if(mut self, bandwidth: crate::Bandwidth, predicate: bool) -> Self {
+        if predicate {
+            self.0.add_bandwidth(bandwidth);
+        }
+        self
+    }
+
+    pub fn bandwidth_if_some(mut self, bandwidth: Option<crate::Bandwidth>) -> Self {
+        if let Some(bandwidth) = bandwidth {
+            self.0.add_bandwidth(bandwidth);
+        }
+        self
+    }
+
+    pub fn bandwidths(mut self, bandwidths: impl IntoIterator<Item = crate::Bandwidth>) -> Self {
+        self.0.add_bandwidths(bandwidths);
+        self
+    }
+
+    pub fn bandwidths_if(
+        mut self,
+        bandwidths: impl IntoIterator<Item = crate::Bandwidth>,
+        predicate: bool,
+    ) -> Self {
+        if predicate {
+            self.0.add_bandwidths(bandwidths);
+        }
+        self
+    }
+
+    pub fn encryption_key(mut self, key: impl Into<crate::Key>) -> Self {
+        self.0.set_encryption_key(key);
+        self
+    }
+
+    pub fn encryption_key_if(
+        mut self,
+        encryption_key: impl Into<crate::Key>,
+        predicate: bool,
+    ) -> Self {
+        if predicate {
+            self.0.set_encryption_key(encryption_key);
+        }
+        self
+    }
+
+    pub fn encryption_key_if_some(mut self, encryption_key: Option<impl Into<crate::Key>>) -> Self {
+        if let Some(encryption_key) = encryption_key {
+            self.0.set_encryption_key(encryption_key);
+        }
+        self
+    }
+
+    pub fn attribute(mut self, attribute: impl Into<crate::Attribute>) -> Self {
+        self.0.add_attribute(attribute);
+        self
+    }
+
+    pub fn attribute_if(mut self, attribute: impl Into<crate::Attribute>, predicate: bool) -> Self {
+        if predicate {
+            self.0.add_attribute(attribute);
+        }
+        self
+    }
+
+    pub fn attribute_if_some(mut self, attribute: Option<impl Into<crate::Attribute>>) -> Self {
+        if let Some(attribute) = attribute {
+            self.0.add_attribute(attribute);
+        }
+        self
+    }
+
+    pub fn attribute_from_str(mut self, attribute: impl ToString) -> Self {
+        self.0.add_attribute_from_str(attribute);
+        self
+    }
+
+    pub fn attribute_from_str_if(mut self, attribute: impl ToString, predicate: bool) -> Self {
+        if predicate {
+            self.0.add_attribute_from_str(attribute);
+        }
+        self
+    }
+
+    pub fn attribute_from_str_if_some(mut self, attribute: Option<impl ToString>) -> Self {
+        if let Some(attribute) = attribute {
+            self.0.add_attribute_from_str(attribute);
+        }
+        self
+    }
+
+    pub fn attribute_with_value(mut self, attribute: impl ToString, value: impl ToString) -> Self {
+        self.0.add_attribute_with_value(attribute, value);
+        self
+    }
+
+    pub fn attribute_with_value_if(
+        mut self,
+        attribute: impl ToString,
+        value: impl ToString,
+        predicate: bool,
+    ) -> Self {
+        if predicate {
+            self.0.add_attribute_with_value(attribute, value);
+        }
+        self
+    }
+
+    pub fn attributes(
+        mut self,
+        attributes: impl IntoIterator<Item = impl Into<crate::Attribute>>,
+    ) -> Self {
+        self.0.add_attributes(attributes);
+        self
+    }
+
+    pub fn attributes_if(
+        mut self,
+        attributes: impl IntoIterator<Item = impl Into<crate::Attribute>>,
+        predicate: bool,
+    ) -> Self {
+        if predicate {
+            self.0.add_attributes(attributes);
+        }
+        self
+    }
+
+    pub fn attributes_from_strs(
+        mut self,
+        attributes: impl IntoIterator<Item = impl ToString>,
+    ) -> Self {
+        self.0.add_attributes_from_strs(attributes);
+        self
+    }
+
+    pub fn attributes_from_strs_if(
+        mut self,
+        attributes: impl IntoIterator<Item = impl ToString>,
+        predicate: bool,
+    ) -> Self {
+        if predicate {
+            self.0.add_attributes_from_strs(attributes);
+        }
+        self
+    }
+
+    pub fn build(self) -> crate::Media {
+        self.0
+    }
+}
+
+/// A [`crate::Session`] builder.
+#[derive(Debug)]
+pub struct Session(crate::Session);
+impl Session {
+    pub fn new(origin: crate::Origin, session_name: impl ToString) -> Self {
+        Self(crate::Session::new(origin, session_name))
+    }
+
+    pub fn session_description(mut self, session_description: impl ToString) -> Self {
+        self.0.set_session_description(session_description);
+        self
+    }
+
+    pub fn session_description_if(
+        mut self,
+        session_description: impl ToString,
+        predicate: bool,
+    ) -> Self {
+        if predicate {
+            self.0.set_session_description(session_description);
+        }
+        self
+    }
+
+    pub fn session_description_if_some(
+        mut self,
+        session_description: Option<impl ToString>,
+    ) -> Self {
+        if let Some(session_description) = session_description {
+            self.0.set_session_description(session_description);
+        }
+        self
+    }
+
+    pub fn uri(mut self, uri: impl ToString) -> Self {
+        self.0.set_uri(uri);
+        self
+    }
+
+    pub fn uri_if(mut self, uri: impl ToString, predicate: bool) -> Self {
+        if predicate {
+            self.0.set_uri(uri);
+        }
+        self
+    }
+
+    pub fn uri_if_some(mut self, uri: Option<impl ToString>) -> Self {
+        if let Some(uri) = uri {
+            self.0.set_uri(uri);
+        }
+        self
+    }
+
+    pub fn email(mut self, email: impl ToString) -> Self {
+        self.0.add_email(email);
+        self
+    }
+
+    pub fn email_if(mut self, email: impl ToString, predicate: bool) -> Self {
+        if predicate {
+            self.0.add_email(email);
+        }
+        self
+    }
+
+    pub fn email_if_some(mut self, email: Option<impl ToString>) -> Self {
+        if let Some(email) = email {
+            self.0.add_email(email);
+        }
+        self
+    }
+
+    pub fn emails(mut self, emails: impl IntoIterator<Item = impl ToString>) -> Self {
+        self.0.add_emails(emails);
+        self
+    }
+
+    pub fn emails_if(
+        mut self,
+        emails: impl IntoIterator<Item = impl ToString>,
+        predicate: bool,
+    ) -> Self {
+        if predicate {
+            self.0.add_emails(emails);
+        }
+        self
+    }
+
+    pub fn phone(mut self, phone: impl ToString) -> Self {
+        self.0.add_phone(phone);
+        self
+    }
+
+    pub fn phone_if(mut self, phone: impl ToString, predicate: bool) -> Self {
+        if predicate {
+            self.0.add_phone(phone);
+        }
+        self
+    }
+
+    pub fn phone_if_some(mut self, phone: Option<impl ToString>) -> Self {
+        if let Some(phone) = phone {
+            self.0.add_phone(phone);
+        }
+        self
+    }
+
+    pub fn phones(mut self, phones: impl IntoIterator<Item = impl ToString>) -> Self {
+        self.0.add_phones(phones);
+        self
+    }
+
+    pub fn phones_if(
+        mut self,
+        phones: impl IntoIterator<Item = impl ToString>,
+        predicate: bool,
+    ) -> Self {
+        if predicate {
+            self.0.add_phones(phones);
+        }
+        self
+    }
+
+    pub fn connection(mut self, connection: impl Into<crate::Connection>) -> Self {
+        self.0.set_connection(connection);
+        self
+    }
+
+    pub fn connection_if(
+        mut self,
+        connection: impl Into<crate::Connection>,
+        predicate: bool,
+    ) -> Self {
+        if predicate {
+            self.0.set_connection(connection);
+        }
+        self
+    }
+
+    pub fn connection_if_some(mut self, connection: Option<impl Into<crate::Connection>>) -> Self {
+        if let Some(connection) = connection {
+            self.0.set_connection(connection);
+        }
+        self
+    }
+
+    pub fn bandwidth(mut self, bandwidth: crate::Bandwidth) -> Self {
+        self.0.add_bandwidth(bandwidth);
+        self
+    }
+
+    pub fn bandwidth_if(mut self, bandwidth: crate::Bandwidth, predicate: bool) -> Self {
+        if predicate {
+            self.0.add_bandwidth(bandwidth);
+        }
+        self
+    }
+
+    pub fn bandwidth_if_some(mut self, bandwidth: Option<crate::Bandwidth>) -> Self {
+        if let Some(bandwidth) = bandwidth {
+            self.0.add_bandwidth(bandwidth);
+        }
+        self
+    }
+
+    pub fn bandwidths(mut self, bandwidths: impl IntoIterator<Item = crate::Bandwidth>) -> Self {
+        self.0.add_bandwidths(bandwidths);
+        self
+    }
+
+    pub fn bandwidths_if(
+        mut self,
+        bandwidths: impl IntoIterator<Item = crate::Bandwidth>,
+        predicate: bool,
+    ) -> Self {
+        if predicate {
+            self.0.add_bandwidths(bandwidths);
+        }
+        self
+    }
+
+    pub fn time(mut self, time: crate::Time) -> Self {
+        self.0.add_time(time);
+        self
+    }
+
+    pub fn time_if(mut self, time: crate::Time, predicate: bool) -> Self {
+        if predicate {
+            self.0.add_time(time);
+        }
+        self
+    }
+
+    pub fn time_if_some(mut self, time: Option<crate::Time>) -> Self {
+        if let Some(time) = time {
+            self.0.add_time(time);
+        }
+        self
+    }
+
+    pub fn times(mut self, times: impl IntoIterator<Item = crate::Time>) -> Self {
+        self.0.add_times(times);
+        self
+    }
+
+    pub fn times_if(
+        mut self,
+        times: impl IntoIterator<Item = crate::Time>,
+        predicate: bool,
+    ) -> Self {
+        if predicate {
+            self.0.add_times(times);
+        }
+        self
+    }
+
+    pub fn times_if_some(mut self, times: Option<impl IntoIterator<Item = crate::Time>>) -> Self {
+        if let Some(times) = times {
+            self.0.add_times(times);
+        }
+        self
+    }
+
+    pub fn time_zone(mut self, time_zone: crate::TimeZone) -> Self {
+        self.0.add_time_zone(time_zone);
+        self
+    }
+
+    pub fn time_zone_if(mut self, time_zone: crate::TimeZone, predicate: bool) -> Self {
+        if predicate {
+            self.0.add_time_zone(time_zone);
+        }
+        self
+    }
+
+    pub fn time_zone_if_some(mut self, time_zone: Option<crate::TimeZone>) -> Self {
+        if let Some(time_zone) = time_zone {
+            self.0.add_time_zone(time_zone);
+        }
+        self
+    }
+
+    pub fn time_zones(mut self, time_zones: impl IntoIterator<Item = crate::TimeZone>) -> Self {
+        self.0.add_time_zones(time_zones);
+        self
+    }
+
+    pub fn time_zones_if(
+        mut self,
+        time_zones: impl IntoIterator<Item = crate::TimeZone>,
+        predicate: bool,
+    ) -> Self {
+        if predicate {
+            self.0.add_time_zones(time_zones);
+        }
+        self
+    }
+
+    pub fn encryption_key(mut self, key: impl Into<crate::Key>) -> Self {
+        self.0.set_encryption_key(key);
+        self
+    }
+
+    pub fn encryption_key_if(
+        mut self,
+        encryption_key: impl Into<crate::Key>,
+        predicate: bool,
+    ) -> Self {
+        if predicate {
+            self.0.set_encryption_key(encryption_key);
+        }
+        self
+    }
+
+    pub fn encryption_key_if_some(mut self, encryption_key: Option<impl Into<crate::Key>>) -> Self {
+        if let Some(encryption_key) = encryption_key {
+            self.0.set_encryption_key(encryption_key);
+        }
+        self
+    }
+
+    pub fn attribute(mut self, attribute: impl Into<crate::Attribute>) -> Self {
+        self.0.add_attribute(attribute);
+        self
+    }
+
+    pub fn attribute_if(mut self, attribute: impl Into<crate::Attribute>, predicate: bool) -> Self {
+        if predicate {
+            self.0.add_attribute(attribute);
+        }
+        self
+    }
+
+    pub fn attribute_if_some(mut self, attribute: Option<impl Into<crate::Attribute>>) -> Self {
+        if let Some(attribute) = attribute {
+            self.0.add_attribute(attribute);
+        }
+        self
+    }
+
+    pub fn attribute_from_str(mut self, attribute: impl ToString) -> Self {
+        self.0.add_attribute_from_str(attribute);
+        self
+    }
+
+    pub fn attribute_from_str_if(mut self, attribute: impl ToString, predicate: bool) -> Self {
+        if predicate {
+            self.0.add_attribute_from_str(attribute);
+        }
+        self
+    }
+
+    pub fn attribute_from_str_if_some(mut self, attribute: Option<impl ToString>) -> Self {
+        if let Some(attribute) = attribute {
+            self.0.add_attribute_from_str(attribute);
+        }
+        self
+    }
+
+    pub fn attribute_with_value(mut self, attribute: impl ToString, value: impl ToString) -> Self {
+        self.0.add_attribute_with_value(attribute, value);
+        self
+    }
+
+    pub fn attribute_with_value_if(
+        mut self,
+        attribute: impl ToString,
+        value: impl ToString,
+        predicate: bool,
+    ) -> Self {
+        if predicate {
+            self.0.add_attribute_with_value(attribute, value);
+        }
+        self
+    }
+
+    pub fn attributes(
+        mut self,
+        attributes: impl IntoIterator<Item = impl Into<crate::Attribute>>,
+    ) -> Self {
+        self.0.add_attributes(attributes);
+        self
+    }
+
+    pub fn attributes_if(
+        mut self,
+        attributes: impl IntoIterator<Item = impl Into<crate::Attribute>>,
+        predicate: bool,
+    ) -> Self {
+        if predicate {
+            self.0.add_attributes(attributes);
+        }
+        self
+    }
+
+    pub fn attributes_if_some(
+        mut self,
+        attributes: Option<impl IntoIterator<Item = impl Into<crate::Attribute>>>,
+    ) -> Self {
+        if let Some(attributes) = attributes {
+            self.0.add_attributes(attributes);
+        }
+        self
+    }
+
+    pub fn attributes_from_strs(
+        mut self,
+        attributes: impl IntoIterator<Item = impl ToString>,
+    ) -> Self {
+        self.0.add_attributes_from_strs(attributes);
+        self
+    }
+
+    pub fn attributes_from_strs_if(
+        mut self,
+        attributes: impl IntoIterator<Item = impl ToString>,
+        predicate: bool,
+    ) -> Self {
+        if predicate {
+            self.0.add_attributes_from_strs(attributes);
+        }
+        self
+    }
+
+    pub fn media(mut self, media: crate::Media) -> Self {
+        self.0.add_media(media);
+        self
+    }
+
+    pub fn media_if(mut self, media: crate::Media, predicate: bool) -> Self {
+        if predicate {
+            self.0.add_media(media);
+        }
+        self
+    }
+
+    pub fn media_if_some(mut self, media: Option<crate::Media>) -> Self {
+        if let Some(media) = media {
+            self.0.add_media(media);
+        }
+        self
+    }
+
+    pub fn medias(mut self, medias: impl IntoIterator<Item = crate::Media>) -> Self {
+        self.0.add_medias(medias);
+        self
+    }
+
+    pub fn medias_if(
+        mut self,
+        medias: impl IntoIterator<Item = crate::Media>,
+        predicate: bool,
+    ) -> Self {
+        if predicate {
+            self.0.add_medias(medias);
+        }
+        self
+    }
+
+    pub fn build(self) -> crate::Session {
+        self.0
+    }
+}
+
+// attributes
+
+/// A [`crate::RtpMap`] builder.
+#[derive(Debug)]
+pub struct RtpMap(attributes::RtpMap);
+impl RtpMap {
+    pub fn new(payload_type: u8, encoding_name: impl ToString, clock_rate: u32) -> Self {
+        Self(attributes::RtpMap::new(
+            payload_type,
+            encoding_name,
+            clock_rate,
+        ))
+    }
+
+    pub fn encoding_params(mut self, encoding_params: impl ToString) -> Self {
+        self.0.set_encoding_params(encoding_params);
+        self
+    }
+
+    pub fn encoding_params_if(mut self, encoding_params: impl ToString, predicate: bool) -> Self {
+        if predicate {
+            self.0.set_encoding_params(encoding_params);
+        }
+        self
+    }
+
+    pub fn build(self) -> attributes::RtpMap {
+        self.0
+    }
+}
+
+/// An [`crate::FmtpParam`] builder.
+#[derive(Debug)]
+pub struct FmtpParam(attributes::FmtpParam);
+impl FmtpParam {
+    pub fn new(param: impl ToString) -> Self {
+        Self(attributes::FmtpParam::new(param))
+    }
+
+    pub fn value(mut self, value: impl ToString) -> Self {
+        self.0.set_value(value);
+        self
+    }
+
+    pub fn value_if(mut self, value: impl ToString, predicate: bool) -> Self {
+        if predicate {
+            self.0.set_value(value);
+        }
+        self
+    }
+
+    pub fn value_if_some(mut self, value: Option<impl ToString>) -> Self {
+        if let Some(value) = value {
+            self.0.set_value(value);
+        }
+        self
+    }
+
+    pub fn build(self) -> attributes::FmtpParam {
+        self.0
+    }
+}
+
+/// An [`crate::Fmtp`] builder.
+#[derive(Debug)]
+pub struct Fmtp(attributes::Fmtp);
+impl Fmtp {
+    pub fn new(fmt: u8) -> Self {
+        Self(attributes::Fmtp::new(fmt))
+    }
+
+    pub fn format_specific_param(mut self, format_specific_param: attributes::FmtpParam) -> Self {
+        self.0.add_format_specific_param(format_specific_param);
+        self
+    }
+
+    pub fn format_specific_param_if(
+        mut self,
+        format_specific_param: attributes::FmtpParam,
+        predicate: bool,
+    ) -> Self {
+        if predicate {
+            self.0.add_format_specific_param(format_specific_param);
+        }
+        self
+    }
+
+    pub fn format_specific_param_if_some(
+        mut self,
+        format_specific_param: Option<attributes::FmtpParam>,
+    ) -> Self {
+        if let Some(format_specific_param) = format_specific_param {
+            self.0.add_format_specific_param(format_specific_param);
+        }
+        self
+    }
+
+    pub fn format_specific_params(
+        mut self,
+        format_specific_params: impl IntoIterator<Item = attributes::FmtpParam>,
+    ) -> Self {
+        self.0.add_format_specific_params(format_specific_params);
+        self
+    }
+
+    pub fn format_specific_params_if(
+        mut self,
+        format_specific_params: impl IntoIterator<Item = attributes::FmtpParam>,
+        predicate: bool,
+    ) -> Self {
+        if predicate {
+            self.0.add_format_specific_params(format_specific_params);
+        }
+        self
+    }
+
+    pub fn build(self) -> attributes::Fmtp {
+        self.0
+    }
+}
+
+/// An [`crate::ExtMap`] builder.
+#[derive(Debug)]
+pub struct ExtMap(attributes::ExtMap);
+impl ExtMap {
+    pub fn new(id: u8, uri: impl ToString) -> Self {
+        Self(attributes::ExtMap::new(id, uri))
+    }
+
+    pub fn direction(mut self, direction: attributes::Direction) -> Self {
+        self.0.set_direction(direction);
+        self
+    }
+
+    pub fn direction_if(mut self, direction: attributes::Direction, predicate: bool) -> Self {
+        if predicate {
+            self.0.set_direction(direction);
+        }
+        self
+    }
+
+    pub fn direction_if_some(mut self, direction: Option<attributes::Direction>) -> Self {
+        if let Some(direction) = direction {
+            self.0.set_direction(direction);
+        }
+        self
+    }
+
+    pub fn attributes(mut self, attributes: impl ToString) -> Self {
+        self.0.set_attributes(attributes);
+        self
+    }
+
+    pub fn attributes_if(mut self, attributes: impl ToString, predicate: bool) -> Self {
+        if predicate {
+            self.0.set_attributes(attributes);
+        }
+        self
+    }
+
+    pub fn build(self) -> attributes::ExtMap {
+        self.0
+    }
+}
+
+/// A [`crate::Fingerprint`] builder.
+#[derive(Debug)]
+pub struct Fingerprint(attributes::Fingerprint);
+impl Fingerprint {
+    pub fn new(hash_func: enums::HashFunc) -> Self {
+        Self(attributes::Fingerprint::new(hash_func))
+    }
+
+    pub fn fingerprint(mut self, fingerprint: impl IntoIterator<Item = u8>) -> Self {
+        self.0.set_fingerprint(fingerprint);
+        self
+    }
+
+    pub fn fingerprint_if(
+        mut self,
+        fingerprint: impl IntoIterator<Item = u8>,
+        predicate: bool,
+    ) -> Self {
+        if predicate {
+            self.0.set_fingerprint(fingerprint);
+        }
+        self
+    }
+
+    pub fn fingerprint_if_some(
+        mut self,
+        fingerprint: Option<impl IntoIterator<Item = u8>>,
+    ) -> Self {
+        if let Some(fingerprint) = fingerprint {
+            self.0.set_fingerprint(fingerprint);
+        }
+        self
+    }
+
+    pub fn build(self) -> attributes::Fingerprint {
+        self.0
+    }
+}
+
+/// A [`crate::Group`] builder.
+#[derive(Debug)]
+pub struct Group(attributes::Group);
+impl Group {
+    pub fn new(semantics: enums::GroupSemantics) -> Self {
+        Self(attributes::Group::new(semantics))
+    }
+
+    pub fn mid_tag(mut self, mid_tag: impl ToString) -> Self {
+        self.0.add_mid_tag(mid_tag);
+        self
+    }
+
+    pub fn mid_tag_if(mut self, mid_tag: impl ToString, predicate: bool) -> Self {
+        if predicate {
+            self.0.add_mid_tag(mid_tag);
+        }
+        self
+    }
+
+    pub fn mid_tag_if_some(mut self, mid_tag: Option<impl ToString>) -> Self {
+        if let Some(mid_tag) = mid_tag {
+            self.0.add_mid_tag(mid_tag);
+        }
+        self
+    }
+
+    pub fn mid_tags(mut self, mid_tags: impl IntoIterator<Item = impl ToString>) -> Self {
+        self.0.add_mid_tags(mid_tags);
+        self
+    }
+
+    pub fn mid_tags_if(
+        mut self,
+        mid_tags: impl IntoIterator<Item = impl ToString>,
+        predicate: bool,
+    ) -> Self {
+        if predicate {
+            self.0.add_mid_tags(mid_tags);
+        }
+        self
+    }
+
+    pub fn build(self) -> attributes::Group {
+        self.0
+    }
+}
+
+/// An [`crate::Ssrc`] builder.
+#[derive(Debug)]
+pub struct Ssrc(attributes::Ssrc);
+impl Ssrc {
+    pub fn new(ssrc_id: u32, attribute: enums::SsrcAttribute) -> Self {
+        Self(attributes::Ssrc::new(ssrc_id, attribute))
+    }
+
+    pub fn value(mut self, value: impl ToString) -> Self {
+        self.0.set_value(value);
+        self
+    }
+
+    pub fn value_if(mut self, value: impl ToString, predicate: bool) -> Self {
+        if predicate {
+            self.0.set_value(value);
+        }
+        self
+    }
+
+    pub fn value_if_some(mut self, value: Option<impl ToString>) -> Self {
+        if let Some(value) = value {
+            self.0.set_value(value);
+        }
+        self
+    }
+
+    pub fn build(self) -> attributes::Ssrc {
+        self.0
+    }
+}
+
+/// An [`crate::SsrcGroup`] builder.
+#[derive(Debug)]
+pub struct SsrcGroup(attributes::SsrcGroup);
+impl SsrcGroup {
+    pub fn new(semantics: enums::GroupSemantics) -> Self {
+        Self(attributes::SsrcGroup::new(semantics))
+    }
+
+    pub fn ssrc_id(mut self, ssrc_id: u32) -> Self {
+        self.0.add_ssrc_id(ssrc_id);
+        self
+    }
+
+    pub fn ssrc_id_if(mut self, ssrc_id: u32, predicate: bool) -> Self {
+        if predicate {
+            self.0.add_ssrc_id(ssrc_id);
+        }
+        self
+    }
+
+    pub fn ssrc_id_if_some(mut self, ssrc_id: Option<u32>) -> Self {
+        if let Some(ssrc_id) = ssrc_id {
+            self.0.add_ssrc_id(ssrc_id);
+        }
+        self
+    }
+
+    pub fn ssrc_ids(mut self, ssrc_ids: impl IntoIterator<Item = u32>) -> Self {
+        self.0.add_ssrc_ids(ssrc_ids);
+        self
+    }
+
+    pub fn ssrc_ids_if(mut self, ssrc_ids: impl IntoIterator<Item = u32>, predicate: bool) -> Self {
+        if predicate {
+            self.0.add_ssrc_ids(ssrc_ids);
+        }
+        self
+    }
+
+    pub fn build(self) -> attributes::SsrcGroup {
+        self.0
+    }
+}
+
+/// A [`crate::SrtpKeyParam`] builder.
+#[derive(Debug)]
+pub struct SrtpKeyParam(attributes::SrtpKeyParam);
+impl SrtpKeyParam {
+    pub fn new(key_and_salt: impl ToString) -> Self {
+        Self(attributes::SrtpKeyParam::new(key_and_salt))
+    }
+
+    pub fn lifetime(mut self, lifetime: u32) -> Self {
+        self.0.set_lifetime(lifetime);
+        self
+    }
+
+    pub fn lifetime_if(mut self, lifetime: u32, predicate: bool) -> Self {
+        if predicate {
+            self.0.set_lifetime(lifetime);
+        }
+        self
+    }
+
+    pub fn lifetime_if_some(mut self, lifetime: Option<u32>) -> Self {
+        if let Some(lifetime) = lifetime {
+            self.0.set_lifetime(lifetime);
+        }
+        self
+    }
+
+    pub fn mki_and_length(mut self, mki: u32, length: u32) -> Self {
+        self.0.set_mki_and_length(mki, length);
+        self
+    }
+
+    pub fn mki_and_length_if(mut self, mki: u32, length: u32, predicate: bool) -> Self {
+        if predicate {
+            self.0.set_mki_and_length(mki, length);
+        }
+        self
+    }
+
+    pub fn build(self) -> attributes::SrtpKeyParam {
+        self.0
+    }
+}
+
+/// A [`crate::Crypto`] builder.
+#[derive(Debug)]
+pub struct Crypto(attributes::Crypto);
+impl Crypto {
+    pub fn new(tag: u32, crypto_suite: enums::CryptoSuite) -> Self {
+        Self(attributes::Crypto::new(tag, crypto_suite))
+    }
+
+    pub fn key_param(mut self, key_param: attributes::SrtpKeyParam) -> Self {
+        self.0.add_key_param(key_param);
+        self
+    }
+
+    pub fn key_param_if(mut self, key_param: attributes::SrtpKeyParam, predicate: bool) -> Self {
+        if predicate {
+            self.0.add_key_param(key_param);
+        }
+        self
+    }
+
+    pub fn key_param_if_some(mut self, key_param: Option<attributes::SrtpKeyParam>) -> Self {
+        if let Some(key_param) = key_param {
+            self.0.add_key_param(key_param);
+        }
+        self
+    }
+
+    pub fn key_params(
+        mut self,
+        key_params: impl IntoIterator<Item = attributes::SrtpKeyParam>,
+    ) -> Self {
+        self.0.add_key_params(key_params);
+        self
+    }
+
+    pub fn key_params_if(
+        mut self,
+        key_params: impl IntoIterator<Item = attributes::SrtpKeyParam>,
+        predicate: bool,
+    ) -> Self {
+        if predicate {
+            self.0.add_key_params(key_params);
+        }
+        self
+    }
+
+    pub fn key_params_if_some(
+        mut self,
+        key_params: Option<impl IntoIterator<Item = attributes::SrtpKeyParam>>,
+    ) -> Self {
+        if let Some(key_params) = key_params {
+            self.0.add_key_params(key_params);
+        }
+        self
+    }
+
+    pub fn session_param(mut self, session_param: enums::SrtpSessionParam) -> Self {
+        self.0.add_session_param(session_param);
+        self
+    }
+
+    pub fn session_param_if(
+        mut self,
+        session_param: enums::SrtpSessionParam,
+        predicate: bool,
+    ) -> Self {
+        if predicate {
+            self.0.add_session_param(session_param);
+        }
+        self
+    }
+
+    pub fn session_param_if_some(mut self, session_param: Option<enums::SrtpSessionParam>) -> Self {
+        if let Some(session_param) = session_param {
+            self.0.add_session_param(session_param);
+        }
+        self
+    }
+
+    pub fn session_params(
+        mut self,
+        session_params: impl IntoIterator<Item = enums::SrtpSessionParam>,
+    ) -> Self {
+        self.0.add_session_params(session_params);
+        self
+    }
+
+    pub fn session_params_if(
+        mut self,
+        session_params: impl IntoIterator<Item = enums::SrtpSessionParam>,
+        predicate: bool,
+    ) -> Self {
+        if predicate {
+            self.0.add_session_params(session_params);
+        }
+        self
+    }
+
+    pub fn build(self) -> attributes::Crypto {
+        self.0
+    }
+}
+
+/// A [`crate::Candidate`] builder.
+#[derive(Debug)]
+pub struct Candidate(attributes::Candidate);
+impl Candidate {
+    pub fn new(
+        foundation: impl ToString,
+        component_id: u32,
+        transport: impl ToString,
+        priority: u64,
+        address: enums::CandidateAddress,
+        port: u16,
+        typ: enums::CandidateType,
+    ) -> Self {
+        Self(attributes::Candidate::new(
+            foundation,
+            component_id,
+            transport,
+            priority,
+            address,
+            port,
+            typ,
+        ))
+    }
+
+    pub fn rel_addr(mut self, rel_addr: impl Into<IpAddr>) -> Self {
+        self.0.set_rel_addr(rel_addr);
+        self
+    }
+
+    pub fn rel_addr_if(mut self, rel_addr: impl Into<IpAddr>, predicate: bool) -> Self {
+        if predicate {
+            self.0.set_rel_addr(rel_addr);
+        }
+        self
+    }
+
+    pub fn rel_addr_if_some(mut self, rel_addr: Option<impl Into<IpAddr>>) -> Self {
+        if let Some(rel_addr) = rel_addr {
+            self.0.set_rel_addr(rel_addr);
+        }
+        self
+    }
+
+    pub fn rel_port(mut self, rel_port: u16) -> Self {
+        self.0.set_rel_port(rel_port);
+        self
+    }
+
+    pub fn rel_port_if(mut self, rel_port: u16, predicate: bool) -> Self {
+        if predicate {
+            self.0.set_rel_port(rel_port);
+        }
+        self
+    }
+
+    pub fn rel_port_if_some(mut self, rel_port: Option<u16>) -> Self {
+        if let Some(rel_port) = rel_port {
+            self.0.set_rel_port(rel_port);
+        }
+        self
+    }
+
+    pub fn extension(mut self, name: impl ToString, value: impl ToString) -> Self {
+        self.0.add_extension(name, value);
+        self
+    }
+
+    pub fn extension_if(
+        mut self,
+        name: impl ToString,
+        value: impl ToString,
+        predicate: bool,
+    ) -> Self {
+        if predicate {
+            self.0.add_extension(name, value);
+        }
+        self
+    }
+
+    pub fn build(self) -> attributes::Candidate {
+        self.0
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::Rtcp;
+
+    #[test]
+    fn builder() {
+        use crate::{
+            Direction, Media, MediaType, Origin, RtpMap, Session, Ssrc, SsrcAttribute,
+            TransportProto,
+        };
+        use std::{net::Ipv4Addr, str::FromStr};
+
+        const SESSION_ID: &str = "1234";
+        const SESSION_NAME: &str = "sdp-type-builder-test";
+        const USER_NAME: &str = "test-user";
+        const UNICAST_ADDRESS: &str = "192.168.0.2";
+        const CONNECTION_ADDRESS: &str = "192.168.0.3";
+        const CONNECTION_PORT: u16 = 5000;
+        const SENDER_ADDRESS: &str = "192.168.0.4";
+        const SENDER_RTCP_PORT: u16 = 5001;
+        const PT: u8 = 96;
+        const ENCODING_NAME: &str = "L24";
+        const AUDIO_RATE: u32 = 48_000;
+        const AUDIO_PARAMS: u8 = 2;
+        const SSRC: u32 = 1234;
+        const CNAME: &str = "user@test.org";
+        const REFCLK: &str = "local";
+
+        let sdp = Session::builder(
+            Origin::builder_with_ip_addr(
+                SESSION_ID,
+                0,
+                Ipv4Addr::from_str(UNICAST_ADDRESS).unwrap(),
+            )
+            .username(USER_NAME)
+            .build(),
+            SESSION_NAME,
+        )
+        .connection(Ipv4Addr::from_str(CONNECTION_ADDRESS).unwrap())
+        .attribute(Direction::SendOnly)
+        .media(
+            Media::builder(
+                MediaType::Audio,
+                CONNECTION_PORT,
+                TransportProto::RtpAvp,
+                PT,
+            )
+            .attribute(RtpMap::with_encoding_params(
+                PT,
+                ENCODING_NAME,
+                AUDIO_RATE,
+                AUDIO_PARAMS,
+            ))
+            .attribute(Ssrc::with_value(SSRC, SsrcAttribute::Cname, CNAME))
+            .attribute(Ssrc::with_value(
+                SSRC,
+                SsrcAttribute::new("ts-refclk"),
+                REFCLK,
+            ))
+            .attribute(Ssrc::with_typed_attribute(
+                SSRC,
+                Rtcp::with_ip_addr(
+                    SENDER_RTCP_PORT,
+                    Ipv4Addr::from_str(SENDER_ADDRESS).unwrap(),
+                ),
+            ))
+            .attribute_from_str("rtcp-mux")
+            .build(),
+        )
+        .build();
+
+        use crate::{AddrType, Attribute, Connection, NetType};
+        assert_eq!(
+            sdp,
+            Session {
+                origin: Origin {
+                    username: Some(USER_NAME.to_string()),
+                    sess_id: SESSION_ID.to_string(),
+                    sess_version: 0,
+                    nettype: NetType::In,
+                    addrtype: AddrType::Ip4,
+                    unicast_address: UNICAST_ADDRESS.to_string(),
+                },
+                session_name: SESSION_NAME.to_string(),
+                connection: Some(Connection {
+                    nettype: NetType::In,
+                    addrtype: AddrType::Ip4,
+                    connection_address: CONNECTION_ADDRESS.to_string(),
+                }),
+                session_description: None,
+                uri: None,
+                emails: vec![],
+                phones: vec![],
+                bandwidths: vec![],
+                times: vec![],
+                time_zones: vec![],
+                key: None,
+                attributes: vec![Attribute {
+                    attribute: "sendonly".to_string(),
+                    value: None
+                }],
+                medias: vec![Media {
+                    media: MediaType::Audio.to_string(),
+                    port: CONNECTION_PORT,
+                    num_ports: None,
+                    proto: TransportProto::RtpAvp.to_string(),
+                    fmt: PT.to_string(),
+                    media_title: None,
+                    connections: vec![],
+                    bandwidths: vec![],
+                    key: None,
+                    attributes: vec![
+                        Attribute {
+                            attribute: "rtpmap".to_string(),
+                            value: Some(format!(
+                                "{PT} {ENCODING_NAME}/{AUDIO_RATE}/{AUDIO_PARAMS}"
+                            )),
+                        },
+                        Attribute {
+                            attribute: "ssrc".to_string(),
+                            value: Some(format!("{SSRC} cname:{CNAME}")),
+                        },
+                        Attribute {
+                            attribute: "ssrc".to_string(),
+                            value: Some(format!("{SSRC} ts-refclk:{REFCLK}")),
+                        },
+                        Attribute {
+                            attribute: "ssrc".to_string(),
+                            value: Some(format!(
+                                "{SSRC} rtcp:{SENDER_RTCP_PORT} IN IP4 {SENDER_ADDRESS}"
+                            )),
+                        },
+                        Attribute {
+                            attribute: "rtcp-mux".to_string(),
+                            value: None,
+                        },
+                    ],
+                }],
+            }
+        )
+    }
+}

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -831,6 +831,15 @@ impl SsrcAttribute {
             SsrcAttribute::Other(attr.to_string())
         }
     }
+
+    pub fn as_str(&self) -> &str {
+        match self {
+            SsrcAttribute::Cname => "cname",
+            SsrcAttribute::PreviousSsrc => "previous-ssrc",
+            SsrcAttribute::Fmtp => "fmtp",
+            SsrcAttribute::Other(other) => other.as_str(),
+        }
+    }
 }
 
 impl<T: TypedAttribute> From<T> for SsrcAttribute {

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -6,6 +6,7 @@
 
 use std::{
     fmt::{Display, Write},
+    net::IpAddr,
     str::FromStr,
 };
 
@@ -35,7 +36,7 @@ impl std::fmt::Display for ParseEnumError {
 /// See [RFC 8866 Section 5.2](https://datatracker.ietf.org/doc/html/rfc8866#section-5.2),
 /// [RFC 8866 Section 5.7](https://datatracker.ietf.org/doc/html/rfc8866#section-5.7) and
 /// [RFC 8866 Section 8.2.6](https://datatracker.ietf.org/doc/html/rfc8866#section-8.2.6) for more details
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum NetType {
     /// Internet
@@ -46,21 +47,25 @@ pub enum NetType {
     Atm,
     /// Public Switched Telephone Network
     Pstn,
+    /// Other
+    Other(String),
 }
 
 impl NetType {
-    pub fn as_str(&self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         match self {
             NetType::In => "IN",
             NetType::Tn => "TN",
             NetType::Atm => "ATM",
             NetType::Pstn => "PSTN",
+            NetType::Other(nettype) => nettype.as_str(),
         }
     }
 }
 
 impl FromStr for NetType {
-    type Err = ParseEnumError;
+    // FIXME use the never type when it is stable
+    type Err = ();
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if "IN".eq_ignore_ascii_case(s) {
@@ -72,8 +77,14 @@ impl FromStr for NetType {
         } else if "PSTN".eq_ignore_ascii_case(s) {
             Ok(NetType::Pstn)
         } else {
-            Err(ParseEnumError::Invalid(s.to_string()))
+            Ok(NetType::Other(s.to_string()))
         }
+    }
+}
+
+impl From<&str> for NetType {
+    fn from(value: &str) -> Self {
+        NetType::from_str(value).expect("infallible")
     }
 }
 
@@ -87,26 +98,35 @@ impl Display for NetType {
 ///
 /// See [RFC 8866 Section 5.2](https://datatracker.ietf.org/doc/html/rfc8866#section-5.2),
 /// [RFC 8866 Section 5.7](https://datatracker.ietf.org/doc/html/rfc8866#section-5.7)
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum AddrType {
     /// IPv4 address
     Ip4,
     /// IPv6 address
     Ip6,
+    /// Other
+    Other(String),
 }
 
 impl AddrType {
-    pub fn as_str(&self) -> &'static str {
+    /// Whether `self` matches an IPv4 or IPv6 address.
+    pub fn is_ip(&self) -> bool {
+        matches!(self, AddrType::Ip4 | AddrType::Ip6)
+    }
+
+    pub fn as_str(&self) -> &str {
         match self {
             AddrType::Ip4 => "IP4",
             AddrType::Ip6 => "IP6",
+            AddrType::Other(other) => other.as_str(),
         }
     }
 }
 
 impl FromStr for AddrType {
-    type Err = ParseEnumError;
+    // FIXME use the never type when it is stable
+    type Err = ();
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if "IP4".eq_ignore_ascii_case(s) {
@@ -114,7 +134,22 @@ impl FromStr for AddrType {
         } else if "IP6".eq_ignore_ascii_case(s) {
             Ok(AddrType::Ip6)
         } else {
-            Err(ParseEnumError::Invalid(s.to_string()))
+            Ok(AddrType::Other(s.to_string()))
+        }
+    }
+}
+
+impl From<&str> for AddrType {
+    fn from(value: &str) -> Self {
+        AddrType::from_str(value).expect("infallible")
+    }
+}
+
+impl From<IpAddr> for AddrType {
+    fn from(addr: IpAddr) -> Self {
+        match addr {
+            IpAddr::V4(_) => AddrType::Ip4,
+            IpAddr::V6(_) => AddrType::Ip6,
         }
     }
 }

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -10,7 +10,7 @@ use std::{
     str::FromStr,
 };
 
-use crate::attributes::SrtpKeyParam;
+use crate::{attributes::SrtpKeyParam, TypedAttribute};
 
 /// Errors while parsing strings to Enum
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -110,6 +110,17 @@ pub enum AddrType {
 }
 
 impl AddrType {
+    pub fn new(addrtype: impl AsRef<str>) -> Self {
+        let addrtype = addrtype.as_ref();
+        if "IP4".eq_ignore_ascii_case(addrtype) {
+            AddrType::Ip4
+        } else if "IP6".eq_ignore_ascii_case(addrtype) {
+            AddrType::Ip6
+        } else {
+            AddrType::Other(addrtype.to_string())
+        }
+    }
+
     /// Whether `self` matches an IPv4 or IPv6 address.
     pub fn is_ip(&self) -> bool {
         matches!(self, AddrType::Ip4 | AddrType::Ip6)
@@ -392,6 +403,43 @@ pub enum HashFunc {
     Other(String),
 }
 
+impl HashFunc {
+    pub fn new(hash_func: impl AsRef<str>) -> Self {
+        let hash_func = hash_func.as_ref();
+
+        if hash_func.eq_ignore_ascii_case("sha-1") {
+            HashFunc::SHA1
+        } else if hash_func.eq_ignore_ascii_case("sha-224") {
+            HashFunc::SHA224
+        } else if hash_func.eq_ignore_ascii_case("sha-256") {
+            HashFunc::SHA256
+        } else if hash_func.eq_ignore_ascii_case("sha-384") {
+            HashFunc::SHA384
+        } else if hash_func.eq_ignore_ascii_case("sha-512") {
+            HashFunc::SHA512
+        } else if hash_func.eq_ignore_ascii_case("md-5") {
+            HashFunc::MD5
+        } else if hash_func.eq_ignore_ascii_case("md-2") {
+            HashFunc::MD2
+        } else {
+            HashFunc::Other(hash_func.to_string())
+        }
+    }
+
+    pub fn as_str(&self) -> &str {
+        match self {
+            HashFunc::SHA1 => "sha-1",
+            HashFunc::SHA224 => "sha-224",
+            HashFunc::SHA256 => "sha-256",
+            HashFunc::SHA384 => "sha-384",
+            HashFunc::SHA512 => "sha-512",
+            HashFunc::MD5 => "md-5",
+            HashFunc::MD2 => "md-2",
+            HashFunc::Other(s) => s.as_str(),
+        }
+    }
+}
+
 /// Semantics for Group Attribute
 ///
 /// See [RFC 5576 Section 12.3](https://datatracker.ietf.org/doc/html/rfc5576#section-12.3)
@@ -426,6 +474,40 @@ pub enum GroupSemantics {
     Other(String),
 }
 
+impl GroupSemantics {
+    pub fn new(semantics: impl AsRef<str>) -> Self {
+        let semantics = semantics.as_ref();
+
+        if "LS".eq_ignore_ascii_case(semantics) {
+            GroupSemantics::LS
+        } else if "FID".eq_ignore_ascii_case(semantics) {
+            GroupSemantics::FID
+        } else if "SRF".eq_ignore_ascii_case(semantics) {
+            GroupSemantics::SRF
+        } else if "ANAT".eq_ignore_ascii_case(semantics) {
+            GroupSemantics::ANAT
+        } else if "FEC".eq_ignore_ascii_case(semantics) {
+            GroupSemantics::FEC
+        } else if "DDP".eq_ignore_ascii_case(semantics) {
+            GroupSemantics::DDP
+        } else {
+            GroupSemantics::Other(semantics.to_string())
+        }
+    }
+
+    pub fn as_str(&self) -> &str {
+        match self {
+            GroupSemantics::LS => "LS",
+            GroupSemantics::FID => "FID",
+            GroupSemantics::SRF => "SRF",
+            GroupSemantics::ANAT => "ANAT",
+            GroupSemantics::DDP => "DDP",
+            GroupSemantics::FEC => "FEC",
+            GroupSemantics::Other(s) => s.as_str(),
+        }
+    }
+}
+
 /// Encryption and authentication algorithms for Crypto attribute
 ///
 /// See [RFC 4568 Section 10.3.2](https://datatracker.ietf.org/doc/html/rfc4568#section-10.3.2)
@@ -444,6 +526,31 @@ pub enum CryptoSuite {
     F8_128HmacSha1_80,
     /// Other Crypto Suite
     Other(String),
+}
+
+impl CryptoSuite {
+    pub fn new(crypto_suite: impl AsRef<str>) -> Self {
+        let crypto_suite = crypto_suite.as_ref();
+
+        if "AES_CM_128_HMAC_SHA1_32".eq_ignore_ascii_case(crypto_suite) {
+            CryptoSuite::AesCm128HmacSha1_32
+        } else if "F8_128_HMAC_SHA1_80".eq_ignore_ascii_case(crypto_suite) {
+            CryptoSuite::F8_128HmacSha1_80
+        } else if "AES_CM_128_HMAC_SHA1_80".eq_ignore_ascii_case(crypto_suite) {
+            CryptoSuite::AesCm128HmacSha1_80
+        } else {
+            CryptoSuite::Other(crypto_suite.to_string())
+        }
+    }
+
+    pub fn as_str(&self) -> &str {
+        match self {
+            CryptoSuite::AesCm128HmacSha1_80 => "AES_CM_128_HMAC_SHA1_80",
+            CryptoSuite::AesCm128HmacSha1_32 => "AES_CM_128_HMAC_SHA1_32",
+            CryptoSuite::F8_128HmacSha1_80 => "F8_128_HMAC_SHA1_80",
+            CryptoSuite::Other(s) => s.as_str(),
+        }
+    }
 }
 
 /// Signals whether FEC is applied before or after SRTP processing
@@ -512,6 +619,34 @@ pub enum CandidateType {
     Relay,
     /// Unknown type
     Other(String),
+}
+
+impl CandidateType {
+    pub fn new(cand_type: impl AsRef<str>) -> Self {
+        let cand_type = cand_type.as_ref();
+
+        if "host".eq_ignore_ascii_case(cand_type) {
+            CandidateType::Host
+        } else if "srflx".eq_ignore_ascii_case(cand_type) {
+            CandidateType::Srflx
+        } else if "prflx".eq_ignore_ascii_case(cand_type) {
+            CandidateType::Prflx
+        } else if "relay".eq_ignore_ascii_case(cand_type) {
+            CandidateType::Relay
+        } else {
+            CandidateType::Other(cand_type.to_string())
+        }
+    }
+
+    pub fn as_str(&self) -> &str {
+        match self {
+            CandidateType::Host => "host",
+            CandidateType::Srflx => "srflx",
+            CandidateType::Prflx => "prflx",
+            CandidateType::Relay => "relay",
+            CandidateType::Other(o) => o.as_str(),
+        }
+    }
 }
 
 /// RTCP Positive feedback values
@@ -681,6 +816,27 @@ pub enum SsrcAttribute {
     Fmtp,
     /// See [RFC 5576 Section 6.4](https://datatracker.ietf.org/doc/html/rfc5576#section-6.4)
     Other(String),
+}
+
+impl SsrcAttribute {
+    pub fn new(attribute: impl AsRef<str>) -> Self {
+        let attr = attribute.as_ref();
+        if "cname".eq_ignore_ascii_case(attr) {
+            SsrcAttribute::Cname
+        } else if "previous-ssrc".eq_ignore_ascii_case(attr) {
+            SsrcAttribute::PreviousSsrc
+        } else if "fmtp".eq_ignore_ascii_case(attr) {
+            SsrcAttribute::Fmtp
+        } else {
+            SsrcAttribute::Other(attr.to_string())
+        }
+    }
+}
+
+impl<T: TypedAttribute> From<T> for SsrcAttribute {
+    fn from(_attr: T) -> Self {
+        SsrcAttribute::new(T::NAME)
+    }
 }
 
 /// Payload format for which feedback messages may be used

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+//
 // Copyright (C) 2019 Sebastian Dröge <sebastian@centricular.com>
 //
 // Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
@@ -47,10 +48,7 @@
 //!    are currently parsed as a plain string and not according to the SDP
 //!    grammar.
 
-use std::{
-    net::{AddrParseError, IpAddr},
-    str::FromStr,
-};
+use std::{net::IpAddr, str::FromStr};
 
 use bstr::*;
 use fallible_iterator::FallibleIterator;
@@ -79,42 +77,29 @@ pub struct Origin {
     /// Session version number.
     pub sess_version: u64,
     /// Type of network for this session.
-    pub nettype: String,
+    pub nettype: NetType,
     /// Type of the `unicast_address`.
-    pub addrtype: String,
+    pub addrtype: AddrType,
     /// Address where the session was created.
     pub unicast_address: String,
 }
 
 impl Origin {
-    /// Tries to parse the `addrtype` `String` of `self` as `AddrType`
-    pub fn try_parse_addrtype(&self) -> Result<AddrType, ParseEnumError> {
-        AddrType::from_str(self.addrtype.as_str())
-    }
-
-    /// Sets the `addrtype` `String` of `self` from the specified `AddrType`
-    pub fn set_addrtype(&mut self, addrtype: AddrType) {
-        self.addrtype = addrtype.to_string();
-    }
-
-    /// Tries to parse the `nettype` `String` of `self` as `NetType`
-    pub fn try_parse_nettype(&self) -> Result<NetType, ParseEnumError> {
-        NetType::from_str(self.nettype.as_str())
-    }
-
-    /// Sets the `nettype` `String` of `self` from the specified `NetType`
-    pub fn set_nettype(&mut self, nettype: NetType) {
-        self.nettype = nettype.to_string();
+    /// Sets the `unicast_address` & `addrtype` of `self` from the specified `IpAddr`
+    pub fn set_unicast_ip_address(&mut self, unicast_address: impl Into<IpAddr>) {
+        let unicast_address = unicast_address.into();
+        self.addrtype = unicast_address.into();
+        self.unicast_address = unicast_address.to_string();
     }
 
     /// Tries to parse the `unicast_address` `String` of `self` as `IpAddr`
-    pub fn try_parse_unicast_address(&self) -> Result<IpAddr, AddrParseError> {
-        self.unicast_address.parse()
-    }
-
-    /// Sets the `unicast_address` `String` of `self` from the specified `IpAddr`
-    pub fn set_unicast_address(&mut self, unicast_address: IpAddr) {
-        self.unicast_address = unicast_address.to_string();
+    ///
+    /// Returns the `Ok` with the parsed `IpAddr` or `Err` with the string address
+    /// if parsing failed.
+    pub fn try_parse_unicast_ip_address(&self) -> Result<IpAddr, &str> {
+        self.unicast_address
+            .parse::<IpAddr>()
+            .map_err(|_| self.unicast_address.as_str())
     }
 }
 
@@ -125,42 +110,29 @@ impl Origin {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Connection {
     /// Type of network for this connection.
-    pub nettype: String,
+    pub nettype: NetType,
     /// Type of the `connection_address`.
-    pub addrtype: String,
+    pub addrtype: AddrType,
     /// Connection address.
     pub connection_address: String,
 }
 
 impl Connection {
-    /// Tries to parse the `addrtype` `String` of `self` as `AddrType`
-    pub fn try_parse_addrtype(&self) -> Result<AddrType, ParseEnumError> {
-        AddrType::from_str(self.addrtype.as_str())
-    }
-
-    /// Sets the `addrtype` `String` of `self` from the specified `AddrType`
-    pub fn set_addrtype(&mut self, addrtype: AddrType) {
-        self.addrtype = addrtype.to_string();
-    }
-
-    /// Tries to parse the `nettype` `String` of `self` as `NetType`
-    pub fn try_parse_nettype(&self) -> Result<NetType, ParseEnumError> {
-        NetType::from_str(self.nettype.as_str())
-    }
-
-    /// Sets the `nettype` `String` of `self` from the specified `NetType`
-    pub fn set_nettype(&mut self, nettype: NetType) {
-        self.nettype = nettype.to_string();
+    /// Sets the `connection_address` & `addrtype` of `self` from the specified `IpAddr`
+    pub fn set_connection_ip_address(&mut self, connection_address: impl Into<IpAddr>) {
+        let connection_address = connection_address.into();
+        self.addrtype = connection_address.into();
+        self.connection_address = connection_address.to_string();
     }
 
     /// Tries to parse the `connection_address` `String` of `self` as `IpAddr`
-    pub fn try_parse_connection_address(&self) -> Result<IpAddr, AddrParseError> {
-        self.connection_address.parse()
-    }
-
-    /// Sets the `connection_address` `String` of `self` from the specified `IpAddr`
-    pub fn set_connection_address(&mut self, connection_address: IpAddr) {
-        self.connection_address = connection_address.to_string();
+    ///
+    /// Returns the `Ok` with the parsed `IpAddr` or `Err` with the string address
+    /// if parsing failed.
+    pub fn try_parse_connection_ip_address(&self) -> Result<IpAddr, &str> {
+        self.connection_address
+            .parse::<IpAddr>()
+            .map_err(|_| self.connection_address.as_str())
     }
 }
 
@@ -482,6 +454,8 @@ impl Session {
 
 #[cfg(test)]
 mod tests {
+    use std::net::Ipv4Addr;
+
     use super::*;
 
     #[test]
@@ -511,10 +485,10 @@ a=extmap:2/sendrecv http://example.com/082005/ext.htm#xmeta short\r
         let mut written = vec![];
         parsed.write(&mut written).unwrap();
         assert_eq!(String::from_utf8_lossy(&written), sdp);
-        assert_eq!(parsed.origin.try_parse_addrtype(), Ok(AddrType::Ip4));
-        assert_ne!(parsed.origin.try_parse_nettype(), Ok(NetType::Pstn));
+        assert_eq!(parsed.origin.addrtype, AddrType::Ip4);
+        assert_ne!(parsed.origin.nettype, NetType::Pstn);
         assert_eq!(
-            parsed.origin.try_parse_unicast_address(),
+            parsed.origin.try_parse_unicast_ip_address(),
             Ok(IpAddr::V4(std::net::Ipv4Addr::new(10, 47, 16, 5)))
         );
         assert_eq!(parsed.medias[0].try_parse_mediatype(), Ok(MediaType::Audio));
@@ -615,7 +589,7 @@ a=extmap:2/sendrecv http://example.com/082005/ext.htm#xmeta short\r
                             port: 53020,
                             nettype: NetType::In,
                             addrtype: AddrType::Ip4,
-                            connection_address: IpAddr::V4(std::net::Ipv4Addr::new(126, 16, 64, 4)),
+                            connection_address: std::net::Ipv4Addr::new(126, 16, 64, 4).to_string(),
                         }
                         .to_string(),
                     ),
@@ -827,5 +801,80 @@ a=extmap:2/sendrecv http://example.com/082005/ext.htm#xmeta short\r
             .expect("Valid vector of attributes");
         assert_eq!(a[2].encoding_name, "L16");
         assert_eq!(a[0].payload_type, 99);
+    }
+
+    #[test]
+    fn origin_parse_address_error() {
+        use std::net::Ipv6Addr;
+
+        let mut origin = Origin {
+            username: None,
+            sess_id: "1234".to_string(),
+            sess_version: 0,
+            nettype: NetType::In,
+            addrtype: AddrType::Ip4,
+            unicast_address: "127.0.0.1".to_string(),
+        };
+
+        assert_eq!(origin.addrtype, AddrType::Ip4);
+        assert_eq!(
+            origin.try_parse_unicast_ip_address().unwrap(),
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+        );
+
+        origin.unicast_address = "127.0.0.1/24".to_string();
+        assert_eq!(
+            origin.try_parse_unicast_ip_address().unwrap_err(),
+            origin.unicast_address
+        );
+
+        origin.unicast_address = "non-ip".to_string();
+        assert_eq!(
+            origin.try_parse_unicast_ip_address().unwrap_err(),
+            origin.unicast_address
+        );
+
+        origin.set_unicast_ip_address(Ipv6Addr::LOCALHOST);
+        assert_eq!(origin.addrtype, AddrType::Ip6);
+        assert_eq!(
+            origin.try_parse_unicast_ip_address().unwrap(),
+            IpAddr::V6(Ipv6Addr::LOCALHOST),
+        );
+    }
+
+    #[test]
+    fn connection_parse_address_error() {
+        use std::net::Ipv6Addr;
+
+        let mut connection = Connection {
+            nettype: NetType::In,
+            addrtype: AddrType::Ip4,
+            connection_address: "127.0.0.1".to_string(),
+        };
+
+        assert_eq!(connection.addrtype, AddrType::Ip4);
+        assert_eq!(
+            connection.try_parse_connection_ip_address().unwrap(),
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+        );
+
+        connection.connection_address = "127.0.0.1/24".to_string();
+        assert_eq!(
+            connection.try_parse_connection_ip_address().unwrap_err(),
+            connection.connection_address
+        );
+
+        connection.connection_address = "non-ip".to_string();
+        assert_eq!(
+            connection.try_parse_connection_ip_address().unwrap_err(),
+            connection.connection_address
+        );
+
+        connection.set_connection_ip_address(Ipv6Addr::LOCALHOST);
+        assert_eq!(connection.addrtype, AddrType::Ip6);
+        assert_eq!(
+            connection.try_parse_connection_ip_address().unwrap(),
+            IpAddr::V6(Ipv6Addr::LOCALHOST),
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,18 @@
 //!     ...
 //! };
 //!
+//! // or
+//! let sdp = sdp_types::Session::new(sdp_types::Origin::new(...), "my-session");
+//!
+//! // or
+//! let sdp = sdp_types::Session::builder(sdp_types::Origin::new(...), "my-session")
+//!     .attribute(...)
+//!     .attribute(...)
+//!     .media(...)
+//!     .media(...)
+//!     ...
+//!     .build();
+//!
 //! // And write it to an `Vec<u8>`
 //! let mut output = Vec::new();
 //! sdp.write(&mut output).unwrap();
@@ -54,6 +66,7 @@ use bstr::*;
 use fallible_iterator::FallibleIterator;
 
 pub mod attributes;
+pub mod builders;
 pub mod enums;
 mod parser;
 mod writer;
@@ -85,14 +98,49 @@ pub struct Origin {
 }
 
 impl Origin {
+    /// Construct an [`Origin`] with the specified IP `unicast_address`
+    pub fn with_ip_addr(
+        sess_id: impl ToString,
+        sess_version: u64,
+        unicast_address: impl Into<IpAddr>,
+    ) -> Self {
+        let unicast_address = unicast_address.into();
+        Origin {
+            username: Default::default(),
+            sess_id: sess_id.to_string(),
+            sess_version,
+            nettype: NetType::In,
+            addrtype: unicast_address.into(),
+            unicast_address: unicast_address.to_string(),
+        }
+    }
+
+    /// Construct an [`Origin`]
+    ///
+    /// See also [`Origin::with_ip_addr`]
+    pub fn new(
+        sess_id: impl ToString,
+        sess_version: u64,
+        nettype: NetType,
+        addrtype: AddrType,
+        unicast_address: impl ToString,
+    ) -> Self {
+        Origin {
+            username: Default::default(),
+            sess_id: sess_id.to_string(),
+            sess_version,
+            nettype,
+            addrtype,
+            unicast_address: unicast_address.to_string(),
+        }
+    }
+
     /// Sets the `unicast_address` & `addrtype` of `self` from the specified `IpAddr`
     pub fn set_unicast_ip_address(&mut self, unicast_address: impl Into<IpAddr>) {
         let unicast_address = unicast_address.into();
         self.addrtype = unicast_address.into();
         self.unicast_address = unicast_address.to_string();
     }
-
-    /// Tries to parse the `unicast_address` `String` of `self` as `IpAddr`
     ///
     /// Returns the `Ok` with the parsed `IpAddr` or `Err` with the string address
     /// if parsing failed.
@@ -100,6 +148,32 @@ impl Origin {
         self.unicast_address
             .parse::<IpAddr>()
             .map_err(|_| self.unicast_address.as_str())
+    }
+
+    pub fn set_username(&mut self, username: impl ToString) {
+        self.username = Some(username.to_string());
+    }
+
+    /// Construct an [`crate::builders::Origin`] with the specified IP `unicast_address`
+    pub fn builder_with_ip_addr(
+        sess_id: impl ToString,
+        sess_version: u64,
+        unicast_address: impl Into<IpAddr>,
+    ) -> builders::Origin {
+        builders::Origin::with_ip_addr(sess_id, sess_version, unicast_address)
+    }
+
+    /// Construct an [`crate::builders::Origin`]
+    ///
+    /// See also [`Origin::builder_with_ip_addr`]
+    pub fn builder(
+        sess_id: impl ToString,
+        sess_version: u64,
+        nettype: NetType,
+        addrtype: AddrType,
+        unicast_address: impl ToString,
+    ) -> builders::Origin {
+        builders::Origin::new(sess_id, sess_version, nettype, addrtype, unicast_address)
     }
 }
 
@@ -118,6 +192,27 @@ pub struct Connection {
 }
 
 impl Connection {
+    /// Construct a [`Connection`] with the specified IP `connection_address`
+    pub fn from_ip_addr(connection_address: impl Into<IpAddr>) -> Self {
+        let connection_address = connection_address.into();
+        Connection {
+            nettype: NetType::In,
+            addrtype: connection_address.into(),
+            connection_address: connection_address.to_string(),
+        }
+    }
+
+    /// Construct a [`Connection`]
+    ///
+    /// See also [`Connection::from_ip_addr`]
+    pub fn new(nettype: NetType, addrtype: AddrType, connection_address: impl ToString) -> Self {
+        Connection {
+            nettype,
+            addrtype,
+            connection_address: connection_address.to_string(),
+        }
+    }
+
     /// Sets the `connection_address` & `addrtype` of `self` from the specified `IpAddr`
     pub fn set_connection_ip_address(&mut self, connection_address: impl Into<IpAddr>) {
         let connection_address = connection_address.into();
@@ -136,6 +231,12 @@ impl Connection {
     }
 }
 
+impl<T: Into<IpAddr>> From<T> for Connection {
+    fn from(ip_addr: T) -> Self {
+        Connection::from_ip_addr(ip_addr)
+    }
+}
+
 /// Bandwidth information for the session or media.
 ///
 /// See [RFC 8866 Section 5.8](https://tools.ietf.org/html/rfc8866#section-5.8) for more details.
@@ -149,6 +250,13 @@ pub struct Bandwidth {
 }
 
 impl Bandwidth {
+    pub fn new(bwtype: BandwidthType, bandwidth: u64) -> Self {
+        Bandwidth {
+            bwtype: bwtype.to_string(),
+            bandwidth,
+        }
+    }
+
     /// Tries to parse the `bwtype` `String` of `self` as `BandwidthType`
     pub fn try_parse_bwtype(&self) -> Result<BandwidthType, ParseEnumError> {
         BandwidthType::from_str(self.bwtype.as_str())
@@ -174,6 +282,28 @@ pub struct Time {
     pub repeats: Vec<Repeat>,
 }
 
+impl Time {
+    pub fn new(start_time: u64, stop_time: u64) -> Self {
+        Time {
+            start_time,
+            stop_time,
+            repeats: Default::default(),
+        }
+    }
+
+    pub fn add_repeat(&mut self, repeat: Repeat) {
+        self.repeats.push(repeat);
+    }
+
+    pub fn add_repeats(&mut self, repeats: impl IntoIterator<Item = Repeat>) {
+        self.repeats.extend(repeats)
+    }
+
+    pub fn builder(start_time: u64, stop_time: u64) -> builders::Time {
+        builders::Time::new(start_time, stop_time)
+    }
+}
+
 /// Repeat times for timing information.
 ///
 /// See [RFC 8866 Section 5.10](https://tools.ietf.org/html/rfc8866#section-5.10) for more details.
@@ -188,6 +318,28 @@ pub struct Repeat {
     pub offsets: Vec<u64>,
 }
 
+impl Repeat {
+    pub fn new(repeat_interval: u64, active_duration: u64) -> Self {
+        Repeat {
+            repeat_interval,
+            active_duration,
+            offsets: Default::default(),
+        }
+    }
+
+    pub fn add_offset(&mut self, offset: u64) {
+        self.offsets.push(offset);
+    }
+
+    pub fn add_offsets(&mut self, offsets: impl IntoIterator<Item = u64>) {
+        self.offsets.extend(offsets)
+    }
+
+    pub fn builder(repeat_interval: u64, active_duration: u64) -> builders::Repeat {
+        builders::Repeat::new(repeat_interval, active_duration)
+    }
+}
+
 /// Time zone information for the session.
 ///
 /// See [RFC 8866 Section 5.11](https://tools.ietf.org/html/rfc8866#section-5.11) for more details.
@@ -198,6 +350,15 @@ pub struct TimeZone {
     pub adjustment_time: u64,
     /// Amount of the adjustment in seconds.
     pub offset: i64,
+}
+
+impl TimeZone {
+    pub fn new(adjustment_time: u64, offset: i64) -> Self {
+        TimeZone {
+            adjustment_time,
+            offset,
+        }
+    }
 }
 
 /// Encryption key for the session or media.
@@ -214,6 +375,21 @@ pub struct Key {
 }
 
 impl Key {
+    pub fn new(method: KeyMethod) -> Self {
+        Key {
+            method: method.to_string(),
+            encryption_key: Default::default(),
+        }
+    }
+
+    /// Constructs a [`crate::Key`] and define its `encryption_key`.
+    pub fn with_encryption_key(method: KeyMethod, encryption_key: impl ToString) -> Self {
+        Key {
+            method: method.to_string(),
+            encryption_key: Some(encryption_key.to_string()),
+        }
+    }
+
     /// Tries to parse the `method` `String` of `self` as `KeyMethod`
     pub fn try_parse_keymethod(&self) -> Result<KeyMethod, ParseEnumError> {
         KeyMethod::from_str(self.method.as_str())
@@ -222,6 +398,15 @@ impl Key {
     /// Sets the `method` `String` of `self` from the specified `KeyMethod`
     pub fn set_keymethod(&mut self, method: KeyMethod) {
         self.method = method.to_string();
+    }
+}
+
+impl From<KeyMethod> for Key {
+    fn from(method: KeyMethod) -> Self {
+        Key {
+            method: method.to_string(),
+            encryption_key: None,
+        }
     }
 }
 
@@ -235,6 +420,26 @@ pub struct Attribute {
     pub attribute: String,
     /// Attribute value.
     pub value: Option<String>,
+}
+
+impl Attribute {
+    /// Constructs an [`crate::Attribute`].
+    ///
+    /// Use [`crate::Attribute::with_value`] if you need to define the `value`.
+    pub fn new(attribute: impl ToString) -> Self {
+        Attribute {
+            attribute: attribute.to_string(),
+            value: Default::default(),
+        }
+    }
+
+    /// Constructs an [`crate::Attribute`] and define its `value`.
+    pub fn with_value(attribute: impl ToString, value: impl ToString) -> Self {
+        Attribute {
+            attribute: attribute.to_string(),
+            value: Some(value.to_string()),
+        }
+    }
 }
 
 /// Media description.
@@ -279,6 +484,88 @@ impl std::fmt::Display for AttributeNotFoundError {
 }
 
 impl Media {
+    pub fn new(media: MediaType, port: u16, proto: TransportProto, fmt: impl ToString) -> Self {
+        Media {
+            media: media.to_string(),
+            port,
+            num_ports: Default::default(),
+            proto: proto.to_string(),
+            fmt: fmt.to_string(),
+            media_title: Default::default(),
+            connections: Default::default(),
+            bandwidths: Default::default(),
+            key: Default::default(),
+            attributes: Default::default(),
+        }
+    }
+
+    pub fn builder(
+        media: MediaType,
+        port: u16,
+        proto: TransportProto,
+        fmt: impl ToString,
+    ) -> builders::Media {
+        builders::Media::new(media, port, proto, fmt)
+    }
+
+    pub fn set_num_ports(&mut self, num_ports: u16) {
+        self.num_ports = Some(num_ports);
+    }
+
+    pub fn set_media_title(&mut self, media_title: impl ToString) {
+        self.media_title = Some(media_title.to_string());
+    }
+
+    pub fn add_connection(&mut self, connection: impl Into<Connection>) {
+        self.connections.push(connection.into());
+    }
+
+    pub fn add_connections(
+        &mut self,
+        connections: impl IntoIterator<Item = impl Into<Connection>>,
+    ) {
+        self.connections
+            .extend(connections.into_iter().map(|c| c.into()))
+    }
+
+    pub fn add_bandwidth(&mut self, bandwidth: Bandwidth) {
+        self.bandwidths.push(bandwidth);
+    }
+
+    pub fn add_bandwidths(&mut self, bandwidths: impl IntoIterator<Item = Bandwidth>) {
+        self.bandwidths.extend(bandwidths)
+    }
+
+    pub fn set_encryption_key(&mut self, key: impl Into<Key>) {
+        self.key = Some(key.into());
+    }
+
+    pub fn add_attribute(&mut self, attribute: impl Into<Attribute>) {
+        self.attributes.push(attribute.into());
+    }
+
+    pub fn add_attribute_from_str(&mut self, attribute: impl ToString) {
+        self.attributes.push(Attribute::new(attribute));
+    }
+
+    pub fn add_attribute_with_value(&mut self, attribute: impl ToString, value: impl ToString) {
+        self.attributes
+            .push(Attribute::with_value(attribute, value));
+    }
+
+    pub fn add_attributes(&mut self, attributes: impl IntoIterator<Item = impl Into<Attribute>>) {
+        self.attributes
+            .extend(attributes.into_iter().map(|a| a.into()))
+    }
+
+    pub fn add_attributes_from_strs(
+        &mut self,
+        attributes: impl IntoIterator<Item = impl ToString>,
+    ) {
+        self.attributes
+            .extend(attributes.into_iter().map(|a| Attribute::new(a)))
+    }
+
     /// Checks if the given attribute exists.
     pub fn has_attribute(&self, name: &str) -> bool {
         self.attributes.iter().any(|a| a.attribute == name)
@@ -393,6 +680,120 @@ pub struct Session {
 }
 
 impl Session {
+    pub fn new(origin: Origin, session_name: impl ToString) -> Self {
+        Session {
+            origin,
+            session_name: session_name.to_string(),
+            session_description: Default::default(),
+            uri: Default::default(),
+            emails: Default::default(),
+            phones: Default::default(),
+            connection: Default::default(),
+            bandwidths: Default::default(),
+            times: Default::default(),
+            time_zones: Default::default(),
+            key: Default::default(),
+            attributes: Default::default(),
+            medias: Default::default(),
+        }
+    }
+
+    pub fn builder(origin: Origin, session_name: impl ToString) -> builders::Session {
+        builders::Session::new(origin, session_name)
+    }
+
+    pub fn set_session_description(&mut self, session_description: impl ToString) {
+        self.session_description = Some(session_description.to_string());
+    }
+
+    pub fn set_uri(&mut self, uri: impl ToString) {
+        self.uri = Some(uri.to_string());
+    }
+
+    pub fn add_email(&mut self, email: impl ToString) {
+        self.emails.push(email.to_string());
+    }
+
+    pub fn add_emails(&mut self, emails: impl IntoIterator<Item = impl ToString>) {
+        self.emails
+            .extend(emails.into_iter().map(|e| e.to_string()));
+    }
+
+    pub fn add_phone(&mut self, phone: impl ToString) {
+        self.phones.push(phone.to_string());
+    }
+
+    pub fn add_phones(&mut self, phones: impl IntoIterator<Item = impl ToString>) {
+        self.phones
+            .extend(phones.into_iter().map(|p| p.to_string()));
+    }
+
+    pub fn set_connection(&mut self, connection: impl Into<Connection>) {
+        self.connection = Some(connection.into());
+    }
+
+    pub fn add_bandwidth(&mut self, bandwidth: Bandwidth) {
+        self.bandwidths.push(bandwidth);
+    }
+
+    pub fn add_bandwidths(&mut self, bandwidths: impl IntoIterator<Item = Bandwidth>) {
+        self.bandwidths.extend(bandwidths);
+    }
+
+    pub fn add_time(&mut self, time: Time) {
+        self.times.push(time);
+    }
+
+    pub fn add_times(&mut self, times: impl IntoIterator<Item = Time>) {
+        self.times.extend(times);
+    }
+
+    pub fn add_time_zone(&mut self, time_zone: TimeZone) {
+        self.time_zones.push(time_zone);
+    }
+
+    pub fn add_time_zones(&mut self, time_zones: impl IntoIterator<Item = TimeZone>) {
+        self.time_zones.extend(time_zones);
+    }
+
+    pub fn set_encryption_key(&mut self, key: impl Into<Key>) {
+        self.key = Some(key.into());
+    }
+
+    pub fn add_attribute(&mut self, attribute: impl Into<Attribute>) {
+        self.attributes.push(attribute.into());
+    }
+
+    pub fn add_attribute_from_str(&mut self, attribute: impl ToString) {
+        self.attributes.push(Attribute::new(attribute));
+    }
+
+    pub fn add_attribute_with_value(&mut self, attribute: impl ToString, value: impl ToString) {
+        self.attributes
+            .push(Attribute::with_value(attribute, value));
+    }
+
+    pub fn add_attributes(&mut self, attributes: impl IntoIterator<Item = impl Into<Attribute>>) {
+        self.attributes
+            .extend(attributes.into_iter().map(|a| a.into()))
+    }
+
+    pub fn add_attributes_from_strs(
+        &mut self,
+        attributes: impl IntoIterator<Item = impl ToString>,
+    ) {
+        self.attributes
+            .extend(attributes.into_iter().map(|a| Attribute::new(a)))
+    }
+
+    pub fn add_media(&mut self, media: Media) {
+        self.medias.push(media);
+    }
+
+    pub fn add_medias(&mut self, medias: impl IntoIterator<Item = Media>) {
+        self.medias.extend(medias)
+    }
+
     /// Checks if the given attribute exists.
     pub fn has_attribute(&self, name: &str) -> bool {
         self.attributes.iter().any(|a| a.attribute == name)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,7 @@ impl Origin {
     }
 
     /// Sets the `addrtype` `String` of `self` from the specified `AddrType`
-    pub fn set_from_addrtype(&mut self, addrtype: AddrType) {
+    pub fn set_addrtype(&mut self, addrtype: AddrType) {
         self.addrtype = addrtype.to_string();
     }
 
@@ -103,7 +103,7 @@ impl Origin {
     }
 
     /// Sets the `nettype` `String` of `self` from the specified `NetType`
-    pub fn set_from_nettype(&mut self, nettype: NetType) {
+    pub fn set_nettype(&mut self, nettype: NetType) {
         self.nettype = nettype.to_string();
     }
 
@@ -139,7 +139,7 @@ impl Connection {
     }
 
     /// Sets the `addrtype` `String` of `self` from the specified `AddrType`
-    pub fn set_from_addrtype(&mut self, addrtype: AddrType) {
+    pub fn set_addrtype(&mut self, addrtype: AddrType) {
         self.addrtype = addrtype.to_string();
     }
 
@@ -149,7 +149,7 @@ impl Connection {
     }
 
     /// Sets the `nettype` `String` of `self` from the specified `NetType`
-    pub fn set_from_nettype(&mut self, nettype: NetType) {
+    pub fn set_nettype(&mut self, nettype: NetType) {
         self.nettype = nettype.to_string();
     }
 
@@ -183,7 +183,7 @@ impl Bandwidth {
     }
 
     /// Sets the `bwtype` `String` of `self` from the specified `BandwidthType`
-    pub fn set_from_bwtype(&mut self, bwtype: BandwidthType) {
+    pub fn set_bwtype(&mut self, bwtype: BandwidthType) {
         self.bwtype = bwtype.to_string();
     }
 }
@@ -248,7 +248,7 @@ impl Key {
     }
 
     /// Sets the `method` `String` of `self` from the specified `KeyMethod`
-    pub fn set_from_keymethod(&mut self, method: KeyMethod) {
+    pub fn set_keymethod(&mut self, method: KeyMethod) {
         self.method = method.to_string();
     }
 }
@@ -348,7 +348,7 @@ impl Media {
     }
 
     /// Sets the `media` `String` of `self` from the specified `MediaType`
-    pub fn set_from_mediatype(&mut self, media: MediaType) {
+    pub fn set_mediatype(&mut self, media: MediaType) {
         self.media = media.to_string();
     }
 
@@ -358,7 +358,7 @@ impl Media {
     }
 
     /// Sets the `proto` `String` of `self` from the specified `TransportProto`
-    pub fn set_from_transport_proto(&mut self, proto: TransportProto) {
+    pub fn set_transport_proto(&mut self, proto: TransportProto) {
         self.proto = proto.to_string();
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,6 +86,38 @@ pub struct Origin {
     pub unicast_address: String,
 }
 
+impl Origin {
+    /// Tries to parse the `addrtype` `String` of `self` as `AddrType`
+    pub fn try_parse_addrtype(&self) -> Result<AddrType, ParseEnumError> {
+        AddrType::from_str(self.addrtype.as_str())
+    }
+
+    /// Sets the `addrtype` `String` of `self` from the specified `AddrType`
+    pub fn set_from_addrtype(&mut self, addrtype: AddrType) {
+        self.addrtype = addrtype.to_string();
+    }
+
+    /// Tries to parse the `nettype` `String` of `self` as `NetType`
+    pub fn try_parse_nettype(&self) -> Result<NetType, ParseEnumError> {
+        NetType::from_str(self.nettype.as_str())
+    }
+
+    /// Sets the `nettype` `String` of `self` from the specified `NetType`
+    pub fn set_from_nettype(&mut self, nettype: NetType) {
+        self.nettype = nettype.to_string();
+    }
+
+    /// Tries to parse the `unicast_address` `String` of `self` as `IpAddr`
+    pub fn try_parse_unicast_address(&self) -> Result<IpAddr, AddrParseError> {
+        self.unicast_address.parse()
+    }
+
+    /// Sets the `unicast_address` `String` of `self` from the specified `IpAddr`
+    pub fn set_unicast_address(&mut self, unicast_address: IpAddr) {
+        self.unicast_address = unicast_address.to_string();
+    }
+}
+
 /// Connection data for the session or media.
 ///
 /// See [RFC 8866 Section 5.7](https://tools.ietf.org/html/rfc8866#section-5.7) for more details.
@@ -100,6 +132,38 @@ pub struct Connection {
     pub connection_address: String,
 }
 
+impl Connection {
+    /// Tries to parse the `addrtype` `String` of `self` as `AddrType`
+    pub fn try_parse_addrtype(&self) -> Result<AddrType, ParseEnumError> {
+        AddrType::from_str(self.addrtype.as_str())
+    }
+
+    /// Sets the `addrtype` `String` of `self` from the specified `AddrType`
+    pub fn set_from_addrtype(&mut self, addrtype: AddrType) {
+        self.addrtype = addrtype.to_string();
+    }
+
+    /// Tries to parse the `nettype` `String` of `self` as `NetType`
+    pub fn try_parse_nettype(&self) -> Result<NetType, ParseEnumError> {
+        NetType::from_str(self.nettype.as_str())
+    }
+
+    /// Sets the `nettype` `String` of `self` from the specified `NetType`
+    pub fn set_from_nettype(&mut self, nettype: NetType) {
+        self.nettype = nettype.to_string();
+    }
+
+    /// Tries to parse the `connection_address` `String` of `self` as `IpAddr`
+    pub fn try_parse_connection_address(&self) -> Result<IpAddr, AddrParseError> {
+        self.connection_address.parse()
+    }
+
+    /// Sets the `connection_address` `String` of `self` from the specified `IpAddr`
+    pub fn set_connection_address(&mut self, connection_address: IpAddr) {
+        self.connection_address = connection_address.to_string();
+    }
+}
+
 /// Bandwidth information for the session or media.
 ///
 /// See [RFC 8866 Section 5.8](https://tools.ietf.org/html/rfc8866#section-5.8) for more details.
@@ -110,6 +174,18 @@ pub struct Bandwidth {
     pub bwtype: String,
     /// Bandwidth.
     pub bandwidth: u64,
+}
+
+impl Bandwidth {
+    /// Tries to parse the `bwtype` `String` of `self` as `BandwidthType`
+    pub fn try_parse_bwtype(&self) -> Result<BandwidthType, ParseEnumError> {
+        BandwidthType::from_str(self.bwtype.as_str())
+    }
+
+    /// Sets the `bwtype` `String` of `self` from the specified `BandwidthType`
+    pub fn set_from_bwtype(&mut self, bwtype: BandwidthType) {
+        self.bwtype = bwtype.to_string();
+    }
 }
 
 /// Timing information of the session.
@@ -165,6 +241,18 @@ pub struct Key {
     pub encryption_key: Option<String>,
 }
 
+impl Key {
+    /// Tries to parse the `method` `String` of `self` as `KeyMethod`
+    pub fn try_parse_keymethod(&self) -> Result<KeyMethod, ParseEnumError> {
+        KeyMethod::from_str(self.method.as_str())
+    }
+
+    /// Sets the `method` `String` of `self` from the specified `KeyMethod`
+    pub fn set_from_keymethod(&mut self, method: KeyMethod) {
+        self.method = method.to_string();
+    }
+}
+
 /// Attributes for the session or media.
 ///
 /// See [RFC 8866 Section 5.13](https://tools.ietf.org/html/rfc8866#section-5.13) for more details.
@@ -203,40 +291,6 @@ pub struct Media {
     pub key: Option<Key>,
     /// Attributes of the media.
     pub attributes: Vec<Attribute>,
-}
-
-/// SDP session description.
-///
-/// See [RFC 8866 Section 5](https://tools.ietf.org/html/rfc8866#section-5) for more details.
-#[derive(Debug, PartialEq, Eq, Clone)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct Session {
-    /// Originator of the session.
-    pub origin: Origin,
-    /// Name of the session.
-    pub session_name: String,
-    /// Session description.
-    pub session_description: Option<String>,
-    /// URI to additional information about the session.
-    pub uri: Option<String>,
-    /// E-Mail contacts for the session.
-    pub emails: Vec<String>,
-    /// Phone contacts for the session.
-    pub phones: Vec<String>,
-    /// Connection data for the session.
-    pub connection: Option<Connection>,
-    /// Bandwidth information for the session.
-    pub bandwidths: Vec<Bandwidth>,
-    /// Timing information for the session.
-    pub times: Vec<Time>,
-    /// Time zone information for the session.
-    pub time_zones: Vec<TimeZone>,
-    /// Encryption key for the session.
-    pub key: Option<Key>,
-    /// Attributes of the session.
-    pub attributes: Vec<Attribute>,
-    /// Media descriptions for this session.
-    pub medias: Vec<Media>,
 }
 
 /// Error returned when an attribute is not found.
@@ -332,6 +386,40 @@ impl Media {
     }
 }
 
+/// SDP session description.
+///
+/// See [RFC 8866 Section 5](https://tools.ietf.org/html/rfc8866#section-5) for more details.
+#[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Session {
+    /// Originator of the session.
+    pub origin: Origin,
+    /// Name of the session.
+    pub session_name: String,
+    /// Session description.
+    pub session_description: Option<String>,
+    /// URI to additional information about the session.
+    pub uri: Option<String>,
+    /// E-Mail contacts for the session.
+    pub emails: Vec<String>,
+    /// Phone contacts for the session.
+    pub phones: Vec<String>,
+    /// Connection data for the session.
+    pub connection: Option<Connection>,
+    /// Bandwidth information for the session.
+    pub bandwidths: Vec<Bandwidth>,
+    /// Timing information for the session.
+    pub times: Vec<Time>,
+    /// Time zone information for the session.
+    pub time_zones: Vec<TimeZone>,
+    /// Encryption key for the session.
+    pub key: Option<Key>,
+    /// Attributes of the session.
+    pub attributes: Vec<Attribute>,
+    /// Media descriptions for this session.
+    pub medias: Vec<Media>,
+}
+
 impl Session {
     /// Checks if the given attribute exists.
     pub fn has_attribute(&self, name: &str) -> bool {
@@ -389,94 +477,6 @@ impl Session {
 
                 T::from_str(s)
             })
-    }
-}
-
-impl Origin {
-    /// Tries to parse the `addrtype` `String` of `self` as `AddrType`
-    pub fn try_parse_addrtype(&self) -> Result<AddrType, ParseEnumError> {
-        AddrType::from_str(self.addrtype.as_str())
-    }
-
-    /// Sets the `addrtype` `String` of `self` from the specified `AddrType`
-    pub fn set_from_addrtype(&mut self, addrtype: AddrType) {
-        self.addrtype = addrtype.to_string();
-    }
-
-    /// Tries to parse the `nettype` `String` of `self` as `NetType`
-    pub fn try_parse_nettype(&self) -> Result<NetType, ParseEnumError> {
-        NetType::from_str(self.nettype.as_str())
-    }
-
-    /// Sets the `nettype` `String` of `self` from the specified `NetType`
-    pub fn set_from_nettype(&mut self, nettype: NetType) {
-        self.nettype = nettype.to_string();
-    }
-
-    /// Tries to parse the `unicast_address` `String` of `self` as `IpAddr`
-    pub fn try_parse_unicast_address(&self) -> Result<IpAddr, AddrParseError> {
-        self.unicast_address.parse()
-    }
-
-    /// Sets the `unicast_address` `String` of `self` from the specified `IpAddr`
-    pub fn set_unicast_address(&mut self, unicast_address: IpAddr) {
-        self.unicast_address = unicast_address.to_string();
-    }
-}
-
-impl Connection {
-    /// Tries to parse the `addrtype` `String` of `self` as `AddrType`
-    pub fn try_parse_addrtype(&self) -> Result<AddrType, ParseEnumError> {
-        AddrType::from_str(self.addrtype.as_str())
-    }
-
-    /// Sets the `addrtype` `String` of `self` from the specified `AddrType`
-    pub fn set_from_addrtype(&mut self, addrtype: AddrType) {
-        self.addrtype = addrtype.to_string();
-    }
-
-    /// Tries to parse the `nettype` `String` of `self` as `NetType`
-    pub fn try_parse_nettype(&self) -> Result<NetType, ParseEnumError> {
-        NetType::from_str(self.nettype.as_str())
-    }
-
-    /// Sets the `nettype` `String` of `self` from the specified `NetType`
-    pub fn set_from_nettype(&mut self, nettype: NetType) {
-        self.nettype = nettype.to_string();
-    }
-
-    /// Tries to parse the `connection_address` `String` of `self` as `IpAddr`
-    pub fn try_parse_connection_address(&self) -> Result<IpAddr, AddrParseError> {
-        self.connection_address.parse()
-    }
-
-    /// Sets the `connection_address` `String` of `self` from the specified `IpAddr`
-    pub fn set_connection_address(&mut self, connection_address: IpAddr) {
-        self.connection_address = connection_address.to_string();
-    }
-}
-
-impl Bandwidth {
-    /// Tries to parse the `bwtype` `String` of `self` as `BandwidthType`
-    pub fn try_parse_bwtype(&self) -> Result<BandwidthType, ParseEnumError> {
-        BandwidthType::from_str(self.bwtype.as_str())
-    }
-
-    /// Sets the `bwtype` `String` of `self` from the specified `BandwidthType`
-    pub fn set_from_bwtype(&mut self, bwtype: BandwidthType) {
-        self.bwtype = bwtype.to_string();
-    }
-}
-
-impl Key {
-    /// Tries to parse the `method` `String` of `self` as `KeyMethod`
-    pub fn try_parse_keymethod(&self) -> Result<KeyMethod, ParseEnumError> {
-        KeyMethod::from_str(self.method.as_str())
-    }
-
-    /// Sets the `method` `String` of `self` from the specified `KeyMethod`
-    pub fn set_from_keymethod(&mut self, method: KeyMethod) {
-        self.method = method.to_string();
     }
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -131,8 +131,8 @@ impl Origin {
             },
             sess_id,
             sess_version,
-            nettype,
-            addrtype,
+            nettype: NetType::from_str(&nettype).expect("infallible"),
+            addrtype: AddrType::from_str(&addrtype).expect("infallible"),
             unicast_address,
         })
     }
@@ -148,8 +148,8 @@ impl Connection {
             parse_str(&mut connection, line.n, "Connection connection-address")?;
 
         Ok(Connection {
-            nettype,
-            addrtype,
+            nettype: NetType::from_str(&nettype).expect("infaillible"),
+            addrtype: AddrType::from_str(&addrtype).expect("infaillible"),
             connection_address,
         })
     }
@@ -573,8 +573,8 @@ impl Session {
             username: None,
             sess_id: String::new(),
             sess_version: 0,
-            nettype: String::new(),
-            addrtype: String::new(),
+            nettype: NetType::Other(String::new()),
+            addrtype: AddrType::Other(String::new()),
             unicast_address: String::new(),
         });
         let session_name = session_name.unwrap_or_default();
@@ -863,7 +863,7 @@ a=rtpmap:8 PCMA/8000/1\r
 
 ";
         let parsed = Session::parse(&sdp[..]).unwrap();
-        assert_eq!(parsed.origin.try_parse_nettype(), Ok(NetType::In));
+        assert_eq!(parsed.origin.nettype, NetType::In);
     }
 
     /// Parses SDP from a Geovision camera which (incorrectly) omits the "t="


### PR DESCRIPTION
This MR adds constructors, setters, adders & builders.

Constructors arguments include all non-optionals & non-collections attributes. `String` arguments use `impl ToString`.

Example:

```rust
let sdp = Session::builder(
    Origin::builder_with_ip_addr(
        SESSION_ID,
        0,
        Ipv4Addr::from_str(UNICAST_ADDRESS).unwrap(),
    )
    .username(USER_NAME)
    .build(),
    SESSION_NAME,
)
.connection_from_ip_addr(Ipv4Addr::from_str(CONNECTION_ADDRESS).unwrap())
.attribute(Direction::SendOnly)
.media(
    Media::builder(
        MediaType::Audio,
        CONNECTION_PORT,
        TransportProto::RtpAvp,
        PT,
    )
    .attribute(RtpMap::with_encoding_params(
        PT,
        ENCODING_NAME,
        AUDIO_RATE,
        AUDIO_PARAMS,
    ))
    .attribute(Ssrc::with_value(SSRC, SsrcAttribute::Cname, CNAME))
    .attribute(Ssrc::with_value(
        SSRC,
        SsrcAttribute::other("ts-refclk"),
        REFCLK,
    ))
    .attribute(Ssrc::with_typed_attribute(
        SSRC,
        Rtcp::with_ip_addr(
            SENDER_RTCP_PORT,
            Ipv4Addr::from_str(SENDER_ADDRESS).unwrap(),
        ),
    ))
    .attribute_from_str("rtcp-mux")
    .build(),
)
.build();
```

The last commit adds a `TypedAttribute` getter for `Ssrc`.

Fixes https://github.com/sdroege/sdp-types/issues/5