### PR TITLE
 Session & Media: add `get_first_attribute_typed()`

### DIFF
--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -54,6 +54,12 @@ pub enum AttributeError {
     Other { error: String, attr: String },
 }
 
+impl AttributeError {
+    pub fn is_attribute_not_found(&self) -> bool {
+        matches!(self, AttributeError::NotFound(_))
+    }
+}
+
 /// RtpMap Attribute
 ///
 /// See [RFC 8866 Section 6.6](https://datatracker.ietf.org/doc/html/rfc8866#section-6.6) for more details

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -605,6 +605,13 @@ impl Media {
         self.proto = proto.to_string();
     }
 
+    /// Gets the first value of the given typed attribute, if existing.
+    pub fn get_first_attribute_typed<T: TypedAttribute>(&self) -> Result<T, AttributeError> {
+        self.attributes_typed()
+            .next()
+            .unwrap_or_else(|| Err(AttributeError::NotFound(T::NAME.to_string())))
+    }
+
     /// Gets an iterator over all attribute values of the given name.
     ///
     /// Each item is a `Result` with `T` in `Ok` and `AttributeError` in `Err`.
@@ -808,6 +815,13 @@ impl Session {
         } else {
             Err(AttributeError::NotFound(name.to_string()))
         }
+    }
+
+    /// Gets the first value of the given typed attribute, if existing.
+    pub fn get_first_attribute_typed<T: TypedAttribute>(&self) -> Result<T, AttributeError> {
+        self.attributes_typed()
+            .next()
+            .unwrap_or_else(|| Err(AttributeError::NotFound(T::NAME.to_string())))
     }
 
     /// Gets an iterator over all attribute values of the given name.
@@ -1045,6 +1059,10 @@ a=extmap:2/sendrecv http://example.com/082005/ext.htm#xmeta short\r
         assert_eq!(r[0].as_ref().unwrap().addrtype, AddrType::Ip4);
         assert_eq!(r[0].as_ref().unwrap().port, 53020);
 
+        let rtcp_attr = media.get_first_attribute_typed::<Rtcp>().unwrap();
+        assert_eq!(rtcp_attr.addrtype, AddrType::Ip4);
+        assert_eq!(rtcp_attr.port, 53020);
+
         assert_eq!(
             media
                 .get_attribute_values("fingerprint")
@@ -1136,6 +1154,13 @@ a=extmap:2/sendrecv http://example.com/082005/ext.htm#xmeta short\r
             .unwrap()
             .unwrap();
         let rtpmap = RtpMap::from_str(v).unwrap();
+        assert_eq!(rtpmap.clock_rate, 90000);
+        assert_eq!(rtpmap.encoding_name, "h263-1998");
+        assert_ne!(rtpmap.encoding_name, "h263");
+        assert_ne!(rtpmap.encoding_params, Some("2".to_string()));
+        assert_eq!(rtpmap.payload_type, 99);
+
+        let rtpmap = session.get_first_attribute_typed::<RtpMap>().unwrap();
         assert_eq!(rtpmap.clock_rate, 90000);
         assert_eq!(rtpmap.encoding_name, "h263-1998");
         assert_ne!(rtpmap.encoding_name, "h263");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -470,19 +470,6 @@ pub struct Media {
     pub attributes: Vec<Attribute>,
 }
 
-/// Error returned when an attribute is not found.
-#[derive(Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct AttributeNotFoundError;
-
-impl std::error::Error for AttributeNotFoundError {}
-
-impl std::fmt::Display for AttributeNotFoundError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
-        write!(f, "Attribute not found")
-    }
-}
-
 impl Media {
     pub fn new(media: MediaType, port: u16, proto: TransportProto, fmt: impl ToString) -> Self {
         Media {
@@ -572,14 +559,11 @@ impl Media {
     }
 
     /// Gets the first value of the given attribute, if existing.
-    pub fn get_first_attribute_value(
-        &self,
-        name: &str,
-    ) -> Result<Option<&str>, AttributeNotFoundError> {
+    pub fn get_first_attribute_value(&self, name: &str) -> Result<Option<&str>, AttributeError> {
         self.attributes
             .iter()
             .find(|a| a.attribute == name)
-            .ok_or(AttributeNotFoundError)
+            .ok_or(AttributeError::NotFound(name.to_string()))
             .map(|a| a.value.as_deref())
     }
 
@@ -587,7 +571,7 @@ impl Media {
     pub fn get_attribute_values<'a>(
         &'a self,
         name: &'a str,
-    ) -> Result<impl Iterator<Item = Option<&'a str>> + 'a, AttributeNotFoundError> {
+    ) -> Result<impl Iterator<Item = Option<&'a str>> + 'a, AttributeError> {
         let mut iter = self
             .attributes
             .iter()
@@ -597,7 +581,7 @@ impl Media {
         if iter.peek().is_some() {
             Ok(iter)
         } else {
-            Err(AttributeNotFoundError)
+            Err(AttributeError::NotFound(name.to_string()))
         }
     }
 
@@ -800,14 +784,11 @@ impl Session {
     }
 
     /// Gets the first value of the given attribute, if existing.
-    pub fn get_first_attribute_value(
-        &self,
-        name: &str,
-    ) -> Result<Option<&str>, AttributeNotFoundError> {
+    pub fn get_first_attribute_value(&self, name: &str) -> Result<Option<&str>, AttributeError> {
         self.attributes
             .iter()
             .find(|a| a.attribute == name)
-            .ok_or(AttributeNotFoundError)
+            .ok_or(AttributeError::NotFound(name.to_string()))
             .map(|a| a.value.as_deref())
     }
 
@@ -815,7 +796,7 @@ impl Session {
     pub fn get_attribute_values<'a>(
         &'a self,
         name: &'a str,
-    ) -> Result<impl Iterator<Item = Option<&'a str>> + 'a, AttributeNotFoundError> {
+    ) -> Result<impl Iterator<Item = Option<&'a str>> + 'a, AttributeError> {
         let mut iter = self
             .attributes
             .iter()
@@ -825,7 +806,7 @@ impl Session {
         if iter.peek().is_some() {
             Ok(iter)
         } else {
-            Err(AttributeNotFoundError)
+            Err(AttributeError::NotFound(name.to_string()))
         }
     }
 
@@ -1020,10 +1001,9 @@ a=extmap:2/sendrecv http://example.com/082005/ext.htm#xmeta short\r
             media.get_first_attribute_value("rtcp"),
             Ok(Some("53020 IN IP4 126.16.64.4"))
         );
-        assert_eq!(
-            media.get_first_attribute_value("foo"),
-            Err(AttributeNotFoundError)
-        );
+        let err = media.get_first_attribute_value("foo").unwrap_err();
+        assert_eq!(err, AttributeError::NotFound("foo".to_string()));
+        assert!(err.is_attribute_not_found());
 
         assert_eq!(
             media
@@ -1163,10 +1143,10 @@ a=extmap:2/sendrecv http://example.com/082005/ext.htm#xmeta short\r
         assert_eq!(rtpmap.payload_type, 99);
 
         assert_eq!(session.get_first_attribute_value("rtcp"), Ok(None));
-        assert_eq!(
-            session.get_first_attribute_value("foo"),
-            Err(AttributeNotFoundError)
-        );
+
+        let err = session.get_first_attribute_value("foo").unwrap_err();
+        assert_eq!(err, AttributeError::NotFound("foo".to_string()));
+        assert!(err.is_attribute_not_found());
 
         assert_eq!(
             session


### PR DESCRIPTION
... similarly to `get_first_attribute_value`.

See also first commit which removes `AttributeNotFoundError` in favor of `AttributeError::NotFound`